### PR TITLE
Feature/match jsonapi naming

### DIFF
--- a/JSONAPI.playground/Pages/Full Client & Server Example.xcplaygroundpage/Contents.swift
+++ b/JSONAPI.playground/Pages/Full Client & Server Example.xcplaygroundpage/Contents.swift
@@ -19,13 +19,13 @@ extension String: CreatableRawIdType {
 // We create a typealias given that we do not expect JSON:API Resource
 // Objects for this particular API to have Metadata or Links associated
 // with them. We also expect them to have String Identifiers.
-typealias JSONEntity<Description: ResourceObjectDescription> = JSONAPI.Entity<Description, NoMetadata, NoLinks, String>
+typealias JSONEntity<Description: ResourceObjectDescription> = JSONAPI.ResourceObject<Description, NoMetadata, NoLinks, String>
 
 // Similarly, we create a typealias for unidentified entities. JSON:API
 // only allows unidentified entities (i.e. no "id" field) for client
 // requests that create new entities. In these situations, the server
 // is expected to assign the new entity a unique ID.
-typealias UnidentifiedJSONEntity<Description: ResourceObjectDescription> = JSONAPI.Entity<Description, NoMetadata, NoLinks, Unidentified>
+typealias UnidentifiedJSONEntity<Description: ResourceObjectDescription> = JSONAPI.ResourceObject<Description, NoMetadata, NoLinks, Unidentified>
 
 // We create typealiases given that we do not expect JSON:API Relationships
 // for this particular API to have Metadata or Links associated
@@ -95,7 +95,7 @@ func articleDocument(includeAuthor: Bool) -> Either<SingleArticleDocument, Singl
 						  links: .none)
 
 	let document = SingleArticleDocument(apiDescription: .none,
-										 body: .init(entity: article),
+										 body: .init(resourceObject: article),
 										 includes: .none,
 										 meta: .none,
 										 links: .none)

--- a/JSONAPI.playground/Pages/Full Client & Server Example.xcplaygroundpage/Contents.swift
+++ b/JSONAPI.playground/Pages/Full Client & Server Example.xcplaygroundpage/Contents.swift
@@ -19,13 +19,13 @@ extension String: CreatableRawIdType {
 // We create a typealias given that we do not expect JSON:API Resource
 // Objects for this particular API to have Metadata or Links associated
 // with them. We also expect them to have String Identifiers.
-typealias JSONEntity<Description: EntityDescription> = JSONAPI.Entity<Description, NoMetadata, NoLinks, String>
+typealias JSONEntity<Description: ResourceObjectDescription> = JSONAPI.Entity<Description, NoMetadata, NoLinks, String>
 
 // Similarly, we create a typealias for unidentified entities. JSON:API
 // only allows unidentified entities (i.e. no "id" field) for client
 // requests that create new entities. In these situations, the server
 // is expected to assign the new entity a unique ID.
-typealias UnidentifiedJSONEntity<Description: EntityDescription> = JSONAPI.Entity<Description, NoMetadata, NoLinks, Unidentified>
+typealias UnidentifiedJSONEntity<Description: ResourceObjectDescription> = JSONAPI.Entity<Description, NoMetadata, NoLinks, Unidentified>
 
 // We create typealiases given that we do not expect JSON:API Relationships
 // for this particular API to have Metadata or Links associated
@@ -40,7 +40,7 @@ typealias Document<PrimaryResourceBody: JSONAPI.ResourceBody, IncludeType: JSONA
 
 // MARK: Entity Definitions
 
-enum AuthorDescription: EntityDescription {
+enum AuthorDescription: ResourceObjectDescription {
 	public static var jsonType: String { return "authors" }
 
 	public struct Attributes: JSONAPI.Attributes {
@@ -52,7 +52,7 @@ enum AuthorDescription: EntityDescription {
 
 typealias Author = JSONEntity<AuthorDescription>
 
-enum ArticleDescription: EntityDescription {
+enum ArticleDescription: ResourceObjectDescription {
 	public static var jsonType: String { return "articles" }
 
 	public struct Attributes: JSONAPI.Attributes {

--- a/JSONAPI.playground/Pages/Full Document Verbose Generation.xcplaygroundpage/Contents.swift
+++ b/JSONAPI.playground/Pages/Full Document Verbose Generation.xcplaygroundpage/Contents.swift
@@ -76,7 +76,7 @@ enum AuthorDescription: ResourceObjectDescription {
 	}
 }
 
-typealias Author = JSONAPI.Entity<AuthorDescription, EntityMetadata, EntityLinks, String>
+typealias Author = JSONAPI.ResourceObject<AuthorDescription, EntityMetadata, EntityLinks, String>
 
 /// Description of an Article entity.
 enum ArticleDescription: ResourceObjectDescription {
@@ -96,7 +96,7 @@ enum ArticleDescription: ResourceObjectDescription {
 	}
 }
 
-typealias Article = JSONAPI.Entity<ArticleDescription, EntityMetadata, EntityLinks, String>
+typealias Article = JSONAPI.ResourceObject<ArticleDescription, EntityMetadata, EntityLinks, String>
 
 /// Metadata associated with the API Description
 struct APIDescriptionMetadata: JSONAPI.Meta {
@@ -196,7 +196,7 @@ let documentLinks = SingleArticleDocumentLinks(otherArticlesByPrimaryAuthor: .in
 																				   meta: .init(expiry: tomorrow)))
 
 let singleArticleDocument = SingleArticleDocument(apiDescription: apiDescription,
-												  body: .init(entity: article),
+												  body: .init(resourceObject: article),
 												  includes: .init(values: [.init(author1), .init(author2), .init(author3)]),
 												  meta: documentMetadata,
 												  links: documentLinks)

--- a/JSONAPI.playground/Pages/Full Document Verbose Generation.xcplaygroundpage/Contents.swift
+++ b/JSONAPI.playground/Pages/Full Document Verbose Generation.xcplaygroundpage/Contents.swift
@@ -64,7 +64,7 @@ struct ToManyRelationshipLinks: JSONAPI.Links {
 }
 
 /// Description of an Author entity.
-enum AuthorDescription: EntityDescription {
+enum AuthorDescription: ResourceObjectDescription {
 	static var jsonType: String { return "authors" }
 
 	struct Attributes: JSONAPI.Attributes {
@@ -79,7 +79,7 @@ enum AuthorDescription: EntityDescription {
 typealias Author = JSONAPI.Entity<AuthorDescription, EntityMetadata, EntityLinks, String>
 
 /// Description of an Article entity.
-enum ArticleDescription: EntityDescription {
+enum ArticleDescription: ResourceObjectDescription {
 	static var jsonType: String { return "articles" }
 
 	struct Attributes: JSONAPI.Attributes {

--- a/JSONAPI.playground/Pages/Usage.xcplaygroundpage/Contents.swift
+++ b/JSONAPI.playground/Pages/Usage.xcplaygroundpage/Contents.swift
@@ -11,7 +11,7 @@ Please enjoy these examples, but allow me the forced casting and the lack of err
 // MARK: - Create a request or response body with one Dog in it
 let dogFromCode = try! Dog(name: "Buddy", owner: nil)
 
-let singleDogDocument = SingleDogDocument(apiDescription: .none, body: .init(entity: dogFromCode), includes: .none, meta: .none, links: .none)
+let singleDogDocument = SingleDogDocument(apiDescription: .none, body: .init(resourceObject: dogFromCode), includes: .none, meta: .none, links: .none)
 
 let singleDogData = try! JSONEncoder().encode(singleDogDocument)
 
@@ -33,7 +33,7 @@ let houses = [House(attributes: .none, relationships: .none, meta: .none, links:
 let people = try! [Person(id: personIds[0], name: ["Gary", "Doe"], favoriteColor: "Orange-Red", friends: [], dogs: [dogs[0], dogs[1]], home: houses[0]), Person(id: personIds[1], name: ["Elise", "Joy"], favoriteColor: "Red", friends: [], dogs: [dogs[2]], home: houses[1])]
 
 let includes = dogs.map { BatchPeopleDocument.Include($0) } + houses.map { BatchPeopleDocument.Include($0) }
-let batchPeopleDocument = BatchPeopleDocument(apiDescription: .none, body: .init(entities: people), includes: .init(values: includes), meta: .none, links: .none)
+let batchPeopleDocument = BatchPeopleDocument(apiDescription: .none, body: .init(resourceObjects: people), includes: .init(values: includes), meta: .none, links: .none)
 let batchPeopleData = try! JSONEncoder().encode(batchPeopleDocument)
 
 // MARK: - Parse a request or response body with multiple people in it and dogs and houses included

--- a/JSONAPI.playground/Sources/Entities.swift
+++ b/JSONAPI.playground/Sources/Entities.swift
@@ -24,7 +24,7 @@ extension String: CreatableRawIdType {
 }
 
 // MARK: - typealiases for convenience
-public typealias ExampleEntity<Description: ResourceObjectDescription> = Entity<Description, NoMetadata, NoLinks, String>
+public typealias ExampleEntity<Description: ResourceObjectDescription> = ResourceObject<Description, NoMetadata, NoLinks, String>
 public typealias ToOne<E: Identifiable> = ToOneRelationship<E, NoMetadata, NoLinks>
 public typealias ToMany<E: Relatable> = ToManyRelationship<E, NoMetadata, NoLinks>
 
@@ -62,9 +62,9 @@ public enum PersonDescription: ResourceObjectDescription {
 
 public typealias Person = ExampleEntity<PersonDescription>
 
-public extension Entity where Description == PersonDescription, MetaType == NoMetadata, LinksType == NoLinks, EntityRawIdType == String {
+public extension ResourceObject where Description == PersonDescription, MetaType == NoMetadata, LinksType == NoLinks, EntityRawIdType == String {
 	init(id: Person.Id? = nil,name: [String], favoriteColor: String, friends: [Person], dogs: [Dog], home: House) throws {
-		self = Person(id: id ?? Person.Id(), attributes: .init(name: .init(value: name), favoriteColor: .init(value: favoriteColor)), relationships: .init(friends: .init(entities: friends), dogs: .init(entities: dogs), home: .init(entity: home)), meta: .none, links: .none)
+		self = Person(id: id ?? Person.Id(), attributes: .init(name: .init(value: name), favoriteColor: .init(value: favoriteColor)), relationships: .init(friends: .init(resourceObjects: friends), dogs: .init(resourceObjects: dogs), home: .init(resourceObject: home)), meta: .none, links: .none)
 	}
 }
 
@@ -119,9 +119,9 @@ public enum AlternativeDogDescription: ResourceObjectDescription {
 
 public typealias AlternativeDog = ExampleEntity<AlternativeDogDescription>
 
-public extension Entity where Description == DogDescription, MetaType == NoMetadata, LinksType == NoLinks, EntityRawIdType == String {
+public extension ResourceObject where Description == DogDescription, MetaType == NoMetadata, LinksType == NoLinks, EntityRawIdType == String {
 	init(name: String, owner: Person?) throws {
-		self = Dog(attributes: .init(name: .init(value: name)), relationships: DogDescription.Relationships(owner: .init(entity: owner)), meta: .none, links: .none)
+		self = Dog(attributes: .init(name: .init(value: name)), relationships: DogDescription.Relationships(owner: .init(resourceObject: owner)), meta: .none, links: .none)
 	}
 
 	init(name: String, owner: Person.Id) throws {

--- a/JSONAPI.playground/Sources/Entities.swift
+++ b/JSONAPI.playground/Sources/Entities.swift
@@ -24,12 +24,12 @@ extension String: CreatableRawIdType {
 }
 
 // MARK: - typealiases for convenience
-public typealias ExampleEntity<Description: EntityDescription> = Entity<Description, NoMetadata, NoLinks, String>
+public typealias ExampleEntity<Description: ResourceObjectDescription> = Entity<Description, NoMetadata, NoLinks, String>
 public typealias ToOne<E: Identifiable> = ToOneRelationship<E, NoMetadata, NoLinks>
 public typealias ToMany<E: Relatable> = ToManyRelationship<E, NoMetadata, NoLinks>
 
 // MARK: - A few resource objects (entities)
-public enum PersonDescription: EntityDescription {
+public enum PersonDescription: ResourceObjectDescription {
 
 	public static var jsonType: String { return "people" }
 	
@@ -68,7 +68,7 @@ public extension Entity where Description == PersonDescription, MetaType == NoMe
 	}
 }
 
-public enum DogDescription: EntityDescription {
+public enum DogDescription: ResourceObjectDescription {
 
 	public static var jsonType: String { return "dogs" }
 
@@ -91,7 +91,7 @@ public enum DogDescription: EntityDescription {
 
 public typealias Dog = ExampleEntity<DogDescription>
 
-public enum AlternativeDogDescription: EntityDescription {
+public enum AlternativeDogDescription: ResourceObjectDescription {
 
 	public static var jsonType: String { return "dogs" }
 
@@ -129,7 +129,7 @@ public extension Entity where Description == DogDescription, MetaType == NoMetad
 	}
 }
 
-public enum HouseDescription: EntityDescription {
+public enum HouseDescription: ResourceObjectDescription {
 
 	public static var jsonType: String { return "houses" }
 

--- a/JSONAPI.podspec
+++ b/JSONAPI.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "JSONAPI"
-  spec.version      = "0.21.0"
+  spec.version      = "0.30.0"
   spec.summary      = "Swift Codable JSON API framework."
 
   # This description is used to generate tags and improve search results.

--- a/Sources/JSONAPI/Document/ResourceBody.swift
+++ b/Sources/JSONAPI/Document/ResourceBody.swift
@@ -30,20 +30,20 @@ public func +<R: AppendableResourceBody>(_ left: R, right: R) -> R {
 public struct SingleResourceBody<Entity: JSONAPI.MaybePrimaryResource>: ResourceBody {
 	public let value: Entity
 
-	public init(entity: Entity) {
-		self.value = entity
+	public init(resourceObject: Entity) {
+		self.value = resourceObject
 	}
 }
 
 public struct ManyResourceBody<Entity: JSONAPI.PrimaryResource>: AppendableResourceBody {
 	public let values: [Entity]
 
-	public init(entities: [Entity]) {
-		values = entities
+	public init(resourceObjects: [Entity]) {
+		values = resourceObjects
 	}
 
 	public func appending(_ other: ManyResourceBody) -> ManyResourceBody {
-		return ManyResourceBody(entities: values + other.values)
+		return ManyResourceBody(resourceObjects: values + other.values)
 	}
 }
 

--- a/Sources/JSONAPI/Resource/Id.swift
+++ b/Sources/JSONAPI/Resource/Id.swift
@@ -69,7 +69,7 @@ public protocol CreatableIdType: IdType {
 	init()
 }
 
-/// An Entity ID. These IDs can be encoded to or decoded from
+/// An ResourceObject ID. These IDs can be encoded to or decoded from
 /// JSON API IDs.
 public struct Id<RawType: MaybeRawId, IdentifiableType: JSONAPI.JSONTyped>: Equatable, OptionalId {
 

--- a/Sources/JSONAPI/Resource/Relationship.swift
+++ b/Sources/JSONAPI/Resource/Relationship.swift
@@ -13,7 +13,7 @@ public protocol RelationshipType {
 	var meta: MetaType { get }
 }
 
-/// An Entity relationship that can be encoded to or decoded from
+/// An ResourceObject relationship that can be encoded to or decoded from
 /// a JSON API "Resource Linkage."
 /// See https://jsonapi.org/format/#document-resource-object-linkage
 /// A convenient typealias might make your code much more legible: `One<ResourceObjectDescription>`
@@ -38,30 +38,30 @@ extension ToOneRelationship where MetaType == NoMetadata, LinksType == NoLinks {
 }
 
 extension ToOneRelationship {
-	public init<E: ResourceObjectType>(entity: E, meta: MetaType, links: LinksType) where E.Id == Identifiable.Identifier {
-		self.init(id: entity.id, meta: meta, links: links)
+	public init<T: ResourceObjectType>(resourceObject: T, meta: MetaType, links: LinksType) where T.Id == Identifiable.Identifier {
+		self.init(id: resourceObject.id, meta: meta, links: links)
 	}
 }
 
 extension ToOneRelationship where MetaType == NoMetadata, LinksType == NoLinks {
-	public init<E: ResourceObjectType>(entity: E) where E.Id == Identifiable.Identifier {
-		self.init(id: entity.id, meta: .none, links: .none)
+	public init<T: ResourceObjectType>(resourceObject: T) where T.Id == Identifiable.Identifier {
+		self.init(id: resourceObject.id, meta: .none, links: .none)
 	}
 }
 
 extension ToOneRelationship where Identifiable: OptionalRelatable {
-	public init<E: ResourceObjectType>(entity: E?, meta: MetaType, links: LinksType) where E.Id == Identifiable.Wrapped.Identifier {
-		self.init(id: entity?.id, meta: meta, links: links)
+	public init<T: ResourceObjectType>(resourceObject: T?, meta: MetaType, links: LinksType) where T.Id == Identifiable.Wrapped.Identifier {
+		self.init(id: resourceObject?.id, meta: meta, links: links)
 	}
 }
 
 extension ToOneRelationship where Identifiable: OptionalRelatable, MetaType == NoMetadata, LinksType == NoLinks {
-	public init<E: ResourceObjectType>(entity: E?) where E.Id == Identifiable.Wrapped.Identifier {
-		self.init(id: entity?.id, meta: .none, links: .none)
+	public init<T: ResourceObjectType>(resourceObject: T?) where T.Id == Identifiable.Wrapped.Identifier {
+		self.init(id: resourceObject?.id, meta: .none, links: .none)
 	}
 }
 
-/// An Entity relationship that can be encoded to or decoded from
+/// An ResourceObject relationship that can be encoded to or decoded from
 /// a JSON API "Resource Linkage."
 /// See https://jsonapi.org/format/#document-resource-object-linkage
 /// A convenient typealias might make your code much more legible: `Many<ResourceObjectDescription>`
@@ -84,8 +84,8 @@ public struct ToManyRelationship<Relatable: JSONAPI.Relatable, MetaType: JSONAPI
 		self.links = links
 	}
 
-	public init<E: ResourceObjectType>(entities: [E], meta: MetaType, links: LinksType) where E.Id == Relatable.Identifier {
-		self.init(ids: entities.map { $0.id }, meta: meta, links: links)
+	public init<T: ResourceObjectType>(resourceObjects: [T], meta: MetaType, links: LinksType) where T.Id == Relatable.Identifier {
+		self.init(ids: resourceObjects.map { $0.id }, meta: meta, links: links)
 	}
 
 	private init(meta: MetaType, links: LinksType) {
@@ -111,8 +111,8 @@ extension ToManyRelationship where MetaType == NoMetadata, LinksType == NoLinks 
 		return .none(withMeta: .none, links: .none)
 	}
 
-	public init<E: ResourceObjectType>(entities: [E]) where E.Id == Relatable.Identifier {
-		self.init(entities: entities, meta: .none, links: .none)
+	public init<T: ResourceObjectType>(resourceObjects: [T]) where T.Id == Relatable.Identifier {
+		self.init(resourceObjects: resourceObjects, meta: .none, links: .none)
 	}
 }
 

--- a/Sources/JSONAPI/Resource/Relationship.swift
+++ b/Sources/JSONAPI/Resource/Relationship.swift
@@ -38,25 +38,25 @@ extension ToOneRelationship where MetaType == NoMetadata, LinksType == NoLinks {
 }
 
 extension ToOneRelationship {
-	public init<E: EntityType>(entity: E, meta: MetaType, links: LinksType) where E.Id == Identifiable.Identifier {
+	public init<E: ResourceObjectType>(entity: E, meta: MetaType, links: LinksType) where E.Id == Identifiable.Identifier {
 		self.init(id: entity.id, meta: meta, links: links)
 	}
 }
 
 extension ToOneRelationship where MetaType == NoMetadata, LinksType == NoLinks {
-	public init<E: EntityType>(entity: E) where E.Id == Identifiable.Identifier {
+	public init<E: ResourceObjectType>(entity: E) where E.Id == Identifiable.Identifier {
 		self.init(id: entity.id, meta: .none, links: .none)
 	}
 }
 
 extension ToOneRelationship where Identifiable: OptionalRelatable {
-	public init<E: EntityType>(entity: E?, meta: MetaType, links: LinksType) where E.Id == Identifiable.Wrapped.Identifier {
+	public init<E: ResourceObjectType>(entity: E?, meta: MetaType, links: LinksType) where E.Id == Identifiable.Wrapped.Identifier {
 		self.init(id: entity?.id, meta: meta, links: links)
 	}
 }
 
 extension ToOneRelationship where Identifiable: OptionalRelatable, MetaType == NoMetadata, LinksType == NoLinks {
-	public init<E: EntityType>(entity: E?) where E.Id == Identifiable.Wrapped.Identifier {
+	public init<E: ResourceObjectType>(entity: E?) where E.Id == Identifiable.Wrapped.Identifier {
 		self.init(id: entity?.id, meta: .none, links: .none)
 	}
 }
@@ -84,7 +84,7 @@ public struct ToManyRelationship<Relatable: JSONAPI.Relatable, MetaType: JSONAPI
 		self.links = links
 	}
 
-	public init<E: EntityType>(entities: [E], meta: MetaType, links: LinksType) where E.Id == Relatable.Identifier {
+	public init<E: ResourceObjectType>(entities: [E], meta: MetaType, links: LinksType) where E.Id == Relatable.Identifier {
 		self.init(ids: entities.map { $0.id }, meta: meta, links: links)
 	}
 
@@ -111,7 +111,7 @@ extension ToManyRelationship where MetaType == NoMetadata, LinksType == NoLinks 
 		return .none(withMeta: .none, links: .none)
 	}
 
-	public init<E: EntityType>(entities: [E]) where E.Id == Relatable.Identifier {
+	public init<E: ResourceObjectType>(entities: [E]) where E.Id == Relatable.Identifier {
 		self.init(entities: entities, meta: .none, links: .none)
 	}
 }

--- a/Sources/JSONAPI/Resource/Relationship.swift
+++ b/Sources/JSONAPI/Resource/Relationship.swift
@@ -16,7 +16,7 @@ public protocol RelationshipType {
 /// An Entity relationship that can be encoded to or decoded from
 /// a JSON API "Resource Linkage."
 /// See https://jsonapi.org/format/#document-resource-object-linkage
-/// A convenient typealias might make your code much more legible: `One<EntityDescription>`
+/// A convenient typealias might make your code much more legible: `One<ResourceObjectDescription>`
 public struct ToOneRelationship<Identifiable: JSONAPI.Identifiable, MetaType: JSONAPI.Meta, LinksType: JSONAPI.Links>: RelationshipType, Equatable {
 
 	public let id: Identifiable.Identifier
@@ -64,7 +64,7 @@ extension ToOneRelationship where Identifiable: OptionalRelatable, MetaType == N
 /// An Entity relationship that can be encoded to or decoded from
 /// a JSON API "Resource Linkage."
 /// See https://jsonapi.org/format/#document-resource-object-linkage
-/// A convenient typealias might make your code much more legible: `Many<EntityDescription>`
+/// A convenient typealias might make your code much more legible: `Many<ResourceObjectDescription>`
 public struct ToManyRelationship<Relatable: JSONAPI.Relatable, MetaType: JSONAPI.Meta, LinksType: JSONAPI.Links>: RelationshipType, Equatable {
 
 	public let ids: [Relatable.Identifier]

--- a/Sources/JSONAPI/Resource/ResourceObject.swift
+++ b/Sources/JSONAPI/Resource/ResourceObject.swift
@@ -40,25 +40,25 @@ public protocol JSONTyped {
 	static var jsonType: String { get }
 }
 
-/// An `EntityProxyDescription` is an `EntityDescription`
+/// A `ResourceObjectProxyDescription` is an `ResourceObjectDescription`
 /// without Codable conformance.
-public protocol EntityProxyDescription: JSONTyped {
+public protocol ResourceObjectProxyDescription: JSONTyped {
 	associatedtype Attributes: Equatable
 	associatedtype Relationships: Equatable
 }
 
-/// An `EntityDescription` describes a JSON API
+/// An `ResourceObjectDescription` describes a JSON API
 /// Resource Object. The Resource Object
 /// itself is encoded and decoded as an
 /// `Entity`, which gets specialized on an
-/// `EntityDescription`.
-public protocol EntityDescription: EntityProxyDescription where Attributes: JSONAPI.Attributes, Relationships: JSONAPI.Relationships {}
+/// `ResourceObjectDescription`.
+public protocol ResourceObjectDescription: ResourceObjectProxyDescription where Attributes: JSONAPI.Attributes, Relationships: JSONAPI.Relationships {}
 
 /// EntityProxy is a protocol that can be used to create
 /// types that _act_ like Entities but cannot be encoded
 /// or decoded as Entities.
 public protocol EntityProxy: Equatable, JSONTyped {
-	associatedtype Description: EntityProxyDescription
+	associatedtype Description: ResourceObjectProxyDescription
 	associatedtype EntityRawIdType: JSONAPI.MaybeRawId
 
 	typealias Id = JSONAPI.Id<EntityRawIdType, Self>
@@ -87,7 +87,7 @@ extension EntityProxy {
 /// EntityType is the protocol that Entity conforms to. This
 /// protocol lets other types accept any Entity as a generic
 /// specialization.
-public protocol EntityType: EntityProxy, PrimaryResource where Description: EntityDescription {
+public protocol EntityType: EntityProxy, PrimaryResource where Description: ResourceObjectDescription {
 	associatedtype Meta: JSONAPI.Meta
 	associatedtype Links: JSONAPI.Links
 }
@@ -98,7 +98,7 @@ public protocol IdentifiableEntityType: EntityType, Relatable where EntityRawIdT
 /// encoded to or decoded from a JSON API
 /// "Resource Object."
 /// See https://jsonapi.org/format/#document-resource-objects
-public struct Entity<Description: JSONAPI.EntityDescription, MetaType: JSONAPI.Meta, LinksType: JSONAPI.Links, EntityRawIdType: JSONAPI.MaybeRawId>: EntityType {
+public struct Entity<Description: JSONAPI.ResourceObjectDescription, MetaType: JSONAPI.Meta, LinksType: JSONAPI.Links, EntityRawIdType: JSONAPI.MaybeRawId>: EntityType {
 
 	public typealias Meta = MetaType
 	public typealias Links = LinksType

--- a/Sources/JSONAPI/Resource/ResourceObject.swift
+++ b/Sources/JSONAPI/Resource/ResourceObject.swift
@@ -54,10 +54,10 @@ public protocol ResourceObjectProxyDescription: JSONTyped {
 /// `ResourceObjectDescription`.
 public protocol ResourceObjectDescription: ResourceObjectProxyDescription where Attributes: JSONAPI.Attributes, Relationships: JSONAPI.Relationships {}
 
-/// EntityProxy is a protocol that can be used to create
+/// ResourceObjectProxy is a protocol that can be used to create
 /// types that _act_ like Entities but cannot be encoded
 /// or decoded as Entities.
-public protocol EntityProxy: Equatable, JSONTyped {
+public protocol ResourceObjectProxy: Equatable, JSONTyped {
 	associatedtype Description: ResourceObjectProxyDescription
 	associatedtype EntityRawIdType: JSONAPI.MaybeRawId
 
@@ -79,26 +79,26 @@ public protocol EntityProxy: Equatable, JSONTyped {
 	var relationships: Relationships { get }
 }
 
-extension EntityProxy {
+extension ResourceObjectProxy {
 	/// The JSON API compliant "type" of this `Entity`.
 	public static var jsonType: String { return Description.jsonType }
 }
 
-/// EntityType is the protocol that Entity conforms to. This
+/// ResourceObjectType is the protocol that Entity conforms to. This
 /// protocol lets other types accept any Entity as a generic
 /// specialization.
-public protocol EntityType: EntityProxy, PrimaryResource where Description: ResourceObjectDescription {
+public protocol ResourceObjectType: ResourceObjectProxy, PrimaryResource where Description: ResourceObjectDescription {
 	associatedtype Meta: JSONAPI.Meta
 	associatedtype Links: JSONAPI.Links
 }
 
-public protocol IdentifiableEntityType: EntityType, Relatable where EntityRawIdType: JSONAPI.RawIdType {}
+public protocol IdentifiableEntityType: ResourceObjectType, Relatable where EntityRawIdType: JSONAPI.RawIdType {}
 
 /// An `Entity` is a single model type that can be
 /// encoded to or decoded from a JSON API
 /// "Resource Object."
 /// See https://jsonapi.org/format/#document-resource-objects
-public struct Entity<Description: JSONAPI.ResourceObjectDescription, MetaType: JSONAPI.Meta, LinksType: JSONAPI.Links, EntityRawIdType: JSONAPI.MaybeRawId>: EntityType {
+public struct Entity<Description: JSONAPI.ResourceObjectDescription, MetaType: JSONAPI.Meta, LinksType: JSONAPI.Links, EntityRawIdType: JSONAPI.MaybeRawId>: ResourceObjectType {
 
 	public typealias Meta = MetaType
 	public typealias Links = LinksType
@@ -437,7 +437,7 @@ public extension Entity where EntityRawIdType: CreatableRawIdType {
 }
 
 // MARK: Attribute Access
-public extension EntityProxy {
+public extension ResourceObjectProxy {
 	/// Access the attribute at the given keypath. This just
 	/// allows you to write `entity[\.propertyName]` instead
 	/// of `entity.attributes.propertyName`.
@@ -475,7 +475,7 @@ public extension EntityProxy {
 }
 
 // MARK: Meta-Attribute Access
-public extension EntityProxy {
+public extension ResourceObjectProxy {
 	/// Access an attribute requiring a transformation on the RawValue _and_
 	/// a secondary transformation on this entity (self).
 	subscript<T>(_ path: KeyPath<Description.Attributes, (Self) -> T>) -> T {
@@ -484,7 +484,7 @@ public extension EntityProxy {
 }
 
 // MARK: Relationship Access
-public extension EntityProxy {
+public extension ResourceObjectProxy {
 	/// Access to an Id of a `ToOneRelationship`.
 	/// This allows you to write `entity ~> \.other` instead
 	/// of `entity.relationships.other.id`.
@@ -526,7 +526,7 @@ public extension EntityProxy {
 }
 
 // MARK: Meta-Relationship Access
-public extension EntityProxy {
+public extension ResourceObjectProxy {
 	/// Access to an Id of a `ToOneRelationship`.
 	/// This allows you to write `entity ~> \.other` instead
 	/// of `entity.relationships.other.id`.

--- a/Sources/JSONAPI/Resource/ResourceObject.swift
+++ b/Sources/JSONAPI/Resource/ResourceObject.swift
@@ -1,16 +1,16 @@
 //
-//  Entity.swift
+//  ResourceObject.swift
 //  JSONAPI
 //
 //  Created by Mathew Polzin on 7/24/18.
 //
 
-/// A JSON API structure within an Entity that contains
+/// A JSON API structure within an ResourceObject that contains
 /// named properties of types `ToOneRelationship` and
 /// `ToManyRelationship`.
 public protocol Relationships: Codable & Equatable {}
 
-/// A JSON API structure within an Entity that contains
+/// A JSON API structure within an ResourceObject that contains
 /// properties of any types that are JSON encodable.
 public protocol Attributes: Codable & Equatable {}
 
@@ -50,7 +50,7 @@ public protocol ResourceObjectProxyDescription: JSONTyped {
 /// An `ResourceObjectDescription` describes a JSON API
 /// Resource Object. The Resource Object
 /// itself is encoded and decoded as an
-/// `Entity`, which gets specialized on an
+/// `ResourceObject`, which gets specialized on an
 /// `ResourceObjectDescription`.
 public protocol ResourceObjectDescription: ResourceObjectProxyDescription where Attributes: JSONAPI.Attributes, Relationships: JSONAPI.Relationships {}
 
@@ -84,35 +84,35 @@ extension ResourceObjectProxy {
 	public static var jsonType: String { return Description.jsonType }
 }
 
-/// ResourceObjectType is the protocol that Entity conforms to. This
-/// protocol lets other types accept any Entity as a generic
+/// ResourceObjectType is the protocol that ResourceObject conforms to. This
+/// protocol lets other types accept any ResourceObject as a generic
 /// specialization.
 public protocol ResourceObjectType: ResourceObjectProxy, PrimaryResource where Description: ResourceObjectDescription {
 	associatedtype Meta: JSONAPI.Meta
 	associatedtype Links: JSONAPI.Links
 }
 
-public protocol IdentifiableEntityType: ResourceObjectType, Relatable where EntityRawIdType: JSONAPI.RawIdType {}
+public protocol IdentifiableResourceObjectType: ResourceObjectType, Relatable where EntityRawIdType: JSONAPI.RawIdType {}
 
-/// An `Entity` is a single model type that can be
+/// An `ResourceObject` is a single model type that can be
 /// encoded to or decoded from a JSON API
 /// "Resource Object."
 /// See https://jsonapi.org/format/#document-resource-objects
-public struct Entity<Description: JSONAPI.ResourceObjectDescription, MetaType: JSONAPI.Meta, LinksType: JSONAPI.Links, EntityRawIdType: JSONAPI.MaybeRawId>: ResourceObjectType {
+public struct ResourceObject<Description: JSONAPI.ResourceObjectDescription, MetaType: JSONAPI.Meta, LinksType: JSONAPI.Links, EntityRawIdType: JSONAPI.MaybeRawId>: ResourceObjectType {
 
 	public typealias Meta = MetaType
 	public typealias Links = LinksType
 
-	/// The `Entity`'s Id. This can be of type `Unidentified` if
+	/// The `ResourceObject`'s Id. This can be of type `Unidentified` if
 	/// the entity is being created clientside and the
 	/// server is being asked to create a unique Id. Otherwise,
 	/// this should be of a type conforming to `IdType`.
-	public let id: Entity.Id
+	public let id: ResourceObject.Id
 	
-	/// The JSON API compliant attributes of this `Entity`.
+	/// The JSON API compliant attributes of this `ResourceObject`.
 	public let attributes: Description.Attributes
 	
-	/// The JSON API compliant relationships of this `Entity`.
+	/// The JSON API compliant relationships of this `ResourceObject`.
 	public let relationships: Description.Relationships
 
 	/// Any additional metadata packaged with the entity.
@@ -121,7 +121,7 @@ public struct Entity<Description: JSONAPI.ResourceObjectDescription, MetaType: J
 	/// Links related to the entity.
 	public let links: LinksType
 	
-	public init(id: Entity.Id, attributes: Description.Attributes, relationships: Description.Relationships, meta: MetaType, links: LinksType) {
+	public init(id: ResourceObject.Id, attributes: Description.Attributes, relationships: Description.Relationships, meta: MetaType, links: LinksType) {
 		self.id = id
 		self.attributes = attributes
 		self.relationships = relationships
@@ -130,20 +130,20 @@ public struct Entity<Description: JSONAPI.ResourceObjectDescription, MetaType: J
 	}
 }
 
-extension Entity: Identifiable, IdentifiableEntityType, Relatable where EntityRawIdType: JSONAPI.RawIdType {
-	public typealias Identifier = Entity.Id
+extension ResourceObject: Identifiable, IdentifiableResourceObjectType, Relatable where EntityRawIdType: JSONAPI.RawIdType {
+	public typealias Identifier = ResourceObject.Id
 }
 
-extension Entity: CustomStringConvertible {
+extension ResourceObject: CustomStringConvertible {
 	public var description: String {
-		return "Entity<\(Entity.jsonType)>(id: \(String(describing: id)), attributes: \(String(describing: attributes)), relationships: \(String(describing: relationships)))"
+		return "ResourceObject<\(ResourceObject.jsonType)>(id: \(String(describing: id)), attributes: \(String(describing: attributes)), relationships: \(String(describing: relationships)))"
 	}
 }
 
 // MARK: Convenience initializers
-extension Entity where EntityRawIdType: CreatableRawIdType {
+extension ResourceObject where EntityRawIdType: CreatableRawIdType {
 	public init(attributes: Description.Attributes, relationships: Description.Relationships, meta: MetaType, links: LinksType) {
-		self.id = Entity.Id()
+		self.id = ResourceObject.Id()
 		self.attributes = attributes
 		self.relationships = relationships
 		self.meta = meta
@@ -151,7 +151,7 @@ extension Entity where EntityRawIdType: CreatableRawIdType {
 	}
 }
 
-extension Entity where EntityRawIdType == Unidentified {
+extension ResourceObject where EntityRawIdType == Unidentified {
 	public init(attributes: Description.Attributes, relationships: Description.Relationships, meta: MetaType, links: LinksType) {
 		self.id = .unidentified
 		self.attributes = attributes
@@ -162,229 +162,229 @@ extension Entity where EntityRawIdType == Unidentified {
 }
 
 /*
-extension Entity where Description.Attributes == NoAttributes {
-	public init(id: Entity.Id, relationships: Description.Relationships, meta: MetaType, links: LinksType) {
+extension ResourceObject where Description.Attributes == NoAttributes {
+	public init(id: ResourceObject.Id, relationships: Description.Relationships, meta: MetaType, links: LinksType) {
 		self.init(id: id, attributes: NoAttributes(), relationships: relationships, meta: meta, links: links)
 	}
 }
 
-extension Entity where Description.Attributes == NoAttributes, MetaType == NoMetadata {
-	public init(id: Entity.Id, relationships: Description.Relationships, links: LinksType) {
+extension ResourceObject where Description.Attributes == NoAttributes, MetaType == NoMetadata {
+	public init(id: ResourceObject.Id, relationships: Description.Relationships, links: LinksType) {
 		self.init(id: id, relationships: relationships, meta: .none, links: links)
 	}
 }
 
-extension Entity where Description.Attributes == NoAttributes, LinksType == NoLinks {
-	public init(id: Entity.Id, relationships: Description.Relationships, meta: MetaType) {
+extension ResourceObject where Description.Attributes == NoAttributes, LinksType == NoLinks {
+	public init(id: ResourceObject.Id, relationships: Description.Relationships, meta: MetaType) {
 		self.init(id: id, relationships: relationships, meta: meta, links: .none)
 	}
 }
 
-extension Entity where Description.Attributes == NoAttributes, MetaType == NoMetadata, LinksType == NoLinks {
-	public init(id: Entity.Id, relationships: Description.Relationships) {
+extension ResourceObject where Description.Attributes == NoAttributes, MetaType == NoMetadata, LinksType == NoLinks {
+	public init(id: ResourceObject.Id, relationships: Description.Relationships) {
 		self.init(id: id, relationships: relationships, links: .none)
 	}
 }
 
-extension Entity where Description.Attributes == NoAttributes, EntityRawIdType: CreatableRawIdType {
+extension ResourceObject where Description.Attributes == NoAttributes, EntityRawIdType: CreatableRawIdType {
 	public init(relationships: Description.Relationships, meta: MetaType, links: LinksType) {
 		self.init(attributes: NoAttributes(), relationships: relationships, meta: meta, links: links)
 	}
 }
 
-extension Entity where Description.Attributes == NoAttributes, MetaType == NoMetadata, EntityRawIdType: CreatableRawIdType {
+extension ResourceObject where Description.Attributes == NoAttributes, MetaType == NoMetadata, EntityRawIdType: CreatableRawIdType {
 	public init(relationships: Description.Relationships, links: LinksType) {
 		self.init(attributes: NoAttributes(), relationships: relationships, meta: .none, links: links)
 	}
 }
 
-extension Entity where Description.Attributes == NoAttributes, LinksType == NoLinks, EntityRawIdType: CreatableRawIdType {
+extension ResourceObject where Description.Attributes == NoAttributes, LinksType == NoLinks, EntityRawIdType: CreatableRawIdType {
 	public init(relationships: Description.Relationships, meta: MetaType) {
 		self.init(attributes: NoAttributes(), relationships: relationships, meta: meta, links: .none)
 	}
 }
 
-extension Entity where Description.Attributes == NoAttributes, MetaType == NoMetadata, LinksType == NoLinks, EntityRawIdType: CreatableRawIdType {
+extension ResourceObject where Description.Attributes == NoAttributes, MetaType == NoMetadata, LinksType == NoLinks, EntityRawIdType: CreatableRawIdType {
 	public init(relationships: Description.Relationships) {
 		self.init(attributes: NoAttributes(), relationships: relationships, meta: .none, links: .none)
 	}
 }
 
-extension Entity where Description.Attributes == NoAttributes, EntityRawIdType == Unidentified {
+extension ResourceObject where Description.Attributes == NoAttributes, EntityRawIdType == Unidentified {
 	public init(relationships: Description.Relationships, meta: MetaType, links: LinksType) {
 		self.init(attributes: NoAttributes(), relationships: relationships, meta: meta, links: links)
 	}
 }
 
-extension Entity where Description.Relationships == NoRelationships {
-	public init(id: Entity.Id, attributes: Description.Attributes, meta: MetaType, links: LinksType) {
+extension ResourceObject where Description.Relationships == NoRelationships {
+	public init(id: ResourceObject.Id, attributes: Description.Attributes, meta: MetaType, links: LinksType) {
 		self.init(id: id, attributes: attributes, relationships: NoRelationships(), meta: meta, links: links)
 	}
 }
 
-extension Entity where Description.Relationships == NoRelationships, MetaType == NoMetadata {
-	public init(id: Entity.Id, attributes: Description.Attributes, links: LinksType) {
+extension ResourceObject where Description.Relationships == NoRelationships, MetaType == NoMetadata {
+	public init(id: ResourceObject.Id, attributes: Description.Attributes, links: LinksType) {
 		self.init(id: id, attributes: attributes, meta: .none, links: links)
 	}
 }
 
-extension Entity where Description.Relationships == NoRelationships, LinksType == NoLinks {
-	public init(id: Entity.Id, attributes: Description.Attributes, meta: MetaType) {
+extension ResourceObject where Description.Relationships == NoRelationships, LinksType == NoLinks {
+	public init(id: ResourceObject.Id, attributes: Description.Attributes, meta: MetaType) {
 		self.init(id: id, attributes: attributes, meta: meta, links: .none)
 	}
 }
 
-extension Entity where Description.Relationships == NoRelationships, MetaType == NoMetadata, LinksType == NoLinks {
-	public init(id: Entity.Id, attributes: Description.Attributes) {
+extension ResourceObject where Description.Relationships == NoRelationships, MetaType == NoMetadata, LinksType == NoLinks {
+	public init(id: ResourceObject.Id, attributes: Description.Attributes) {
 		self.init(id: id, attributes: attributes, meta: .none, links: .none)
 	}
 }
 
-extension Entity where Description.Relationships == NoRelationships, EntityRawIdType: CreatableRawIdType {
+extension ResourceObject where Description.Relationships == NoRelationships, EntityRawIdType: CreatableRawIdType {
 	public init(attributes: Description.Attributes, meta: MetaType, links: LinksType) {
 		self.init(attributes: attributes, relationships: NoRelationships(), meta: meta, links: links)
 	}
 }
 
-extension Entity where Description.Relationships == NoRelationships, MetaType == NoMetadata, EntityRawIdType: CreatableRawIdType {
+extension ResourceObject where Description.Relationships == NoRelationships, MetaType == NoMetadata, EntityRawIdType: CreatableRawIdType {
 	public init(attributes: Description.Attributes, links: LinksType) {
 		self.init(attributes: attributes, relationships: NoRelationships(), meta: .none, links: links)
 	}
 }
 
-extension Entity where Description.Relationships == NoRelationships, LinksType == NoLinks, EntityRawIdType: CreatableRawIdType {
+extension ResourceObject where Description.Relationships == NoRelationships, LinksType == NoLinks, EntityRawIdType: CreatableRawIdType {
 	public init(attributes: Description.Attributes, meta: MetaType) {
 		self.init(attributes: attributes, relationships: NoRelationships(), meta: meta, links: .none)
 	}
 }
 
-extension Entity where Description.Relationships == NoRelationships, MetaType == NoMetadata, LinksType == NoLinks, EntityRawIdType: CreatableRawIdType {
+extension ResourceObject where Description.Relationships == NoRelationships, MetaType == NoMetadata, LinksType == NoLinks, EntityRawIdType: CreatableRawIdType {
 	public init(attributes: Description.Attributes) {
 		self.init(attributes: attributes, relationships: NoRelationships(), meta: .none, links: .none)
 	}
 }
 
-extension Entity where Description.Relationships == NoRelationships, EntityRawIdType == Unidentified {
+extension ResourceObject where Description.Relationships == NoRelationships, EntityRawIdType == Unidentified {
 	public init(attributes: Description.Attributes, meta: MetaType, links: LinksType) {
 		self.init(attributes: attributes, relationships: NoRelationships(), meta: meta, links: links)
 	}
 }
 
-extension Entity where Description.Relationships == NoRelationships, MetaType == NoMetadata, EntityRawIdType == Unidentified {
+extension ResourceObject where Description.Relationships == NoRelationships, MetaType == NoMetadata, EntityRawIdType == Unidentified {
 	public init(attributes: Description.Attributes, links: LinksType) {
 		self.init(attributes: attributes, relationships: NoRelationships(), meta: .none, links: links)
 	}
 }
 
-extension Entity where Description.Relationships == NoRelationships, LinksType == NoLinks, EntityRawIdType == Unidentified {
+extension ResourceObject where Description.Relationships == NoRelationships, LinksType == NoLinks, EntityRawIdType == Unidentified {
 	public init(attributes: Description.Attributes, meta: MetaType) {
 		self.init(attributes: attributes, relationships: NoRelationships(), meta: meta, links: .none)
 	}
 }
 
-extension Entity where Description.Relationships == NoRelationships, MetaType == NoMetadata, LinksType == NoLinks, EntityRawIdType == Unidentified {
+extension ResourceObject where Description.Relationships == NoRelationships, MetaType == NoMetadata, LinksType == NoLinks, EntityRawIdType == Unidentified {
 	public init(attributes: Description.Attributes) {
 		self.init(attributes: attributes, relationships: NoRelationships(), meta: .none, links: .none)
 	}
 }
 
-extension Entity where Description.Attributes == NoAttributes, Description.Relationships == NoRelationships {
-	public init(id: Entity.Id, meta: MetaType, links: LinksType) {
+extension ResourceObject where Description.Attributes == NoAttributes, Description.Relationships == NoRelationships {
+	public init(id: ResourceObject.Id, meta: MetaType, links: LinksType) {
 		self.init(id: id, attributes: NoAttributes(), relationships: NoRelationships(), meta: meta, links: links)
 	}
 }
 
-extension Entity where Description.Attributes == NoAttributes, Description.Relationships == NoRelationships, MetaType == NoMetadata {
-	public init(id: Entity.Id, links: LinksType) {
+extension ResourceObject where Description.Attributes == NoAttributes, Description.Relationships == NoRelationships, MetaType == NoMetadata {
+	public init(id: ResourceObject.Id, links: LinksType) {
 		self.init(id: id, attributes: NoAttributes(), relationships: NoRelationships(), meta: .none, links: links)
 	}
 }
 
-extension Entity where Description.Attributes == NoAttributes, Description.Relationships == NoRelationships, LinksType == NoLinks {
-	public init(id: Entity.Id, meta: MetaType) {
+extension ResourceObject where Description.Attributes == NoAttributes, Description.Relationships == NoRelationships, LinksType == NoLinks {
+	public init(id: ResourceObject.Id, meta: MetaType) {
 		self.init(id: id, attributes: NoAttributes(), relationships: NoRelationships(), meta: meta, links: .none)
 	}
 }
 
-extension Entity where Description.Attributes == NoAttributes, Description.Relationships == NoRelationships, MetaType == NoMetadata, LinksType == NoLinks {
-	public init(id: Entity.Id) {
+extension ResourceObject where Description.Attributes == NoAttributes, Description.Relationships == NoRelationships, MetaType == NoMetadata, LinksType == NoLinks {
+	public init(id: ResourceObject.Id) {
 		self.init(id: id, attributes: NoAttributes(), relationships: NoRelationships(), meta: .none, links: .none)
 	}
 }
 
-extension Entity where Description.Attributes == NoAttributes, Description.Relationships == NoRelationships, EntityRawIdType: CreatableRawIdType {
+extension ResourceObject where Description.Attributes == NoAttributes, Description.Relationships == NoRelationships, EntityRawIdType: CreatableRawIdType {
 	public init(meta: MetaType, links: LinksType) {
 		self.init(attributes: NoAttributes(), relationships: NoRelationships(), meta: meta, links: links)
 	}
 }
 
-extension Entity where Description.Attributes == NoAttributes, Description.Relationships == NoRelationships, MetaType == NoMetadata, EntityRawIdType: CreatableRawIdType {
+extension ResourceObject where Description.Attributes == NoAttributes, Description.Relationships == NoRelationships, MetaType == NoMetadata, EntityRawIdType: CreatableRawIdType {
 	public init(links: LinksType) {
 		self.init(attributes: NoAttributes(), relationships: NoRelationships(), meta: .none, links: links)
 	}
 }
 
-extension Entity where Description.Attributes == NoAttributes, Description.Relationships == NoRelationships, LinksType == NoLinks, EntityRawIdType: CreatableRawIdType {
+extension ResourceObject where Description.Attributes == NoAttributes, Description.Relationships == NoRelationships, LinksType == NoLinks, EntityRawIdType: CreatableRawIdType {
 	public init(meta: MetaType) {
 		self.init(attributes: NoAttributes(), relationships: NoRelationships(), meta: meta, links: .none)
 	}
 }
 
-extension Entity where Description.Attributes == NoAttributes, Description.Relationships == NoRelationships, MetaType == NoMetadata, LinksType == NoLinks, EntityRawIdType: CreatableRawIdType {
+extension ResourceObject where Description.Attributes == NoAttributes, Description.Relationships == NoRelationships, MetaType == NoMetadata, LinksType == NoLinks, EntityRawIdType: CreatableRawIdType {
 	public init() {
 		self.init(attributes: NoAttributes(), relationships: NoRelationships(), meta: .none, links: .none)
 	}
 }
 
-extension Entity where MetaType == NoMetadata {
-	public init(id: Entity.Id, attributes: Description.Attributes, relationships: Description.Relationships, links: LinksType) {
+extension ResourceObject where MetaType == NoMetadata {
+	public init(id: ResourceObject.Id, attributes: Description.Attributes, relationships: Description.Relationships, links: LinksType) {
 		self.init(id: id, attributes: attributes, relationships: relationships, meta: .none, links: links)
 	}
 }
 
-extension Entity where MetaType == NoMetadata, EntityRawIdType: CreatableRawIdType {
+extension ResourceObject where MetaType == NoMetadata, EntityRawIdType: CreatableRawIdType {
 	public init(attributes: Description.Attributes, relationships: Description.Relationships, links: LinksType) {
 		self.init(attributes: attributes, relationships: relationships, meta: .none, links: links)
 	}
 }
 
-extension Entity where MetaType == NoMetadata, EntityRawIdType == Unidentified {
+extension ResourceObject where MetaType == NoMetadata, EntityRawIdType == Unidentified {
 	public init(attributes: Description.Attributes, relationships: Description.Relationships, links: LinksType) {
 		self.init(attributes: attributes, relationships: relationships, meta: .none, links: links)
 	}
 }
 
-extension Entity where LinksType == NoLinks {
-	public init(id: Entity.Id, attributes: Description.Attributes, relationships: Description.Relationships, meta: MetaType) {
+extension ResourceObject where LinksType == NoLinks {
+	public init(id: ResourceObject.Id, attributes: Description.Attributes, relationships: Description.Relationships, meta: MetaType) {
 		self.init(id: id, attributes: attributes, relationships: relationships, meta: meta, links: .none)
 	}
 }
 
-extension Entity where LinksType == NoLinks, EntityRawIdType: CreatableRawIdType {
+extension ResourceObject where LinksType == NoLinks, EntityRawIdType: CreatableRawIdType {
 	public init(attributes: Description.Attributes, relationships: Description.Relationships, meta: MetaType) {
 		self.init(attributes: attributes, relationships: relationships, meta: meta, links: .none)
 	}
 }
 
-extension Entity where LinksType == NoLinks, EntityRawIdType == Unidentified {
+extension ResourceObject where LinksType == NoLinks, EntityRawIdType == Unidentified {
 	public init(attributes: Description.Attributes, relationships: Description.Relationships, meta: MetaType) {
 		self.init(attributes: attributes, relationships: relationships, meta: meta, links: .none)
 	}
 }
 
-extension Entity where MetaType == NoMetadata, LinksType == NoLinks {
-	public init(id: Entity.Id, attributes: Description.Attributes, relationships: Description.Relationships) {
+extension ResourceObject where MetaType == NoMetadata, LinksType == NoLinks {
+	public init(id: ResourceObject.Id, attributes: Description.Attributes, relationships: Description.Relationships) {
 		self.init(id: id, attributes: attributes, relationships: relationships, meta: .none, links: .none)
 	}
 }
 
-extension Entity where MetaType == NoMetadata, LinksType == NoLinks, EntityRawIdType: CreatableRawIdType {
+extension ResourceObject where MetaType == NoMetadata, LinksType == NoLinks, EntityRawIdType: CreatableRawIdType {
 	public init(attributes: Description.Attributes, relationships: Description.Relationships) {
 		self.init(attributes: attributes, relationships: relationships, meta: .none, links: .none)
 	}
 }
 
-extension Entity where MetaType == NoMetadata, LinksType == NoLinks, EntityRawIdType == Unidentified {
+extension ResourceObject where MetaType == NoMetadata, LinksType == NoLinks, EntityRawIdType == Unidentified {
 	public init(attributes: Description.Attributes, relationships: Description.Relationships) {
 		self.init(attributes: attributes, relationships: relationships, meta: .none, links: .none)
 	}
@@ -392,69 +392,69 @@ extension Entity where MetaType == NoMetadata, LinksType == NoLinks, EntityRawId
 */
 
 // MARK: Pointer for Relationships use.
-public extension Entity where EntityRawIdType: JSONAPI.RawIdType {
+public extension ResourceObject where EntityRawIdType: JSONAPI.RawIdType {
 
-	/// An Entity.Pointer is a `ToOneRelationship` with no metadata or links.
-	/// This is just a convenient way to reference an Entity so that
+	/// An ResourceObject.Pointer is a `ToOneRelationship` with no metadata or links.
+	/// This is just a convenient way to reference an ResourceObject so that
 	/// other Entities' Relationships can be built up from it.
-	typealias Pointer = ToOneRelationship<Entity, NoMetadata, NoLinks>
+	typealias Pointer = ToOneRelationship<ResourceObject, NoMetadata, NoLinks>
 
-	/// Entity.Pointers is a `ToManyRelationship` with no metadata or links.
+	/// ResourceObject.Pointers is a `ToManyRelationship` with no metadata or links.
 	/// This is just a convenient way to reference a bunch of Entities so
 	/// that other Entities' Relationships can be built up from them.
-	typealias Pointers = ToManyRelationship<Entity, NoMetadata, NoLinks>
+	typealias Pointers = ToManyRelationship<ResourceObject, NoMetadata, NoLinks>
 
-	/// Get a pointer to this entity that can be used as a
-	/// relationship to another entity.
+	/// Get a pointer to this resource object that can be used as a
+	/// relationship to another resource object.
 	var pointer: Pointer {
-		return Pointer(entity: self)
+		return Pointer(resourceObject: self)
 	}
 
-	func pointer<MType: JSONAPI.Meta, LType: JSONAPI.Links>(withMeta meta: MType, links: LType) -> ToOneRelationship<Entity, MType, LType> {
-		return ToOneRelationship(entity: self, meta: meta, links: links)
+	func pointer<MType: JSONAPI.Meta, LType: JSONAPI.Links>(withMeta meta: MType, links: LType) -> ToOneRelationship<ResourceObject, MType, LType> {
+		return ToOneRelationship(resourceObject: self, meta: meta, links: links)
 	}
 }
 
 // MARK: Identifying Unidentified Entities
-public extension Entity where EntityRawIdType == Unidentified {
-	/// Create a new Entity from this one with a newly created
+public extension ResourceObject where EntityRawIdType == Unidentified {
+	/// Create a new ResourceObject from this one with a newly created
 	/// unique Id of the given type.
-	func identified<RawIdType: CreatableRawIdType>(byType: RawIdType.Type) -> Entity<Description, MetaType, LinksType, RawIdType> {
+	func identified<RawIdType: CreatableRawIdType>(byType: RawIdType.Type) -> ResourceObject<Description, MetaType, LinksType, RawIdType> {
 		return .init(attributes: attributes, relationships: relationships, meta: meta, links: links)
 	}
 
-	/// Create a new Entity from this one with the given Id.
-	func identified<RawIdType: JSONAPI.RawIdType>(by id: RawIdType) -> Entity<Description, MetaType, LinksType, RawIdType> {
-		return .init(id: Entity<Description, MetaType, LinksType, RawIdType>.Identifier(rawValue: id), attributes: attributes, relationships: relationships, meta: meta, links: links)
+	/// Create a new ResourceObject from this one with the given Id.
+	func identified<RawIdType: JSONAPI.RawIdType>(by id: RawIdType) -> ResourceObject<Description, MetaType, LinksType, RawIdType> {
+		return .init(id: ResourceObject<Description, MetaType, LinksType, RawIdType>.Identifier(rawValue: id), attributes: attributes, relationships: relationships, meta: meta, links: links)
 	}
 }
 
-public extension Entity where EntityRawIdType: CreatableRawIdType {
-	/// Create a copy of this Entity with a new unique Id.
-	func withNewIdentifier() -> Entity {
-		return Entity(attributes: attributes, relationships: relationships, meta: meta, links: links)
+public extension ResourceObject where EntityRawIdType: CreatableRawIdType {
+	/// Create a copy of this ResourceObject with a new unique Id.
+	func withNewIdentifier() -> ResourceObject {
+		return ResourceObject(attributes: attributes, relationships: relationships, meta: meta, links: links)
 	}
 }
 
 // MARK: Attribute Access
 public extension ResourceObjectProxy {
 	/// Access the attribute at the given keypath. This just
-	/// allows you to write `entity[\.propertyName]` instead
-	/// of `entity.attributes.propertyName`.
+	/// allows you to write `resourceObject[\.propertyName]` instead
+	/// of `resourceObject.attributes.propertyName`.
 	subscript<T: AttributeType>(_ path: KeyPath<Description.Attributes, T>) -> T.ValueType {
 		return attributes[keyPath: path].value
 	}
 
 	/// Access the attribute at the given keypath. This just
-	/// allows you to write `entity[\.propertyName]` instead
-	/// of `entity.attributes.propertyName`.
+	/// allows you to write `resourceObject[\.propertyName]` instead
+	/// of `resourceObject.attributes.propertyName`.
 	subscript<T: AttributeType>(_ path: KeyPath<Description.Attributes, T?>) -> T.ValueType? {
 		return attributes[keyPath: path]?.value
 	}
 
 	/// Access the attribute at the given keypath. This just
-	/// allows you to write `entity[\.propertyName]` instead
-	/// of `entity.attributes.propertyName`.
+	/// allows you to write `resourceObject[\.propertyName]` instead
+	/// of `resourceObject.attributes.propertyName`.
 	subscript<T: AttributeType, U>(_ path: KeyPath<Description.Attributes, T?>) -> U? where T.ValueType == U? {
 		// Implementation Note: Handles Transform that returns optional
 		// type.
@@ -462,8 +462,8 @@ public extension ResourceObjectProxy {
 	}
 
 	/// Access the storage of the attribute at the given keypath. This just
-	/// allows you to write `entity[\.propertyName]` instead
-	/// of `entity.attributes.propertyName`.
+    /// allows you to write `resourceObject[direct: \.propertyName]` instead
+	/// of `resourceObject.attributes.propertyName`.
     /// Most of the subscripts dig into an `AttributeType`. This subscript
     /// returns the `AttributeType` (or another type, if you are accessing
     /// an attribute that is not stored in an `AttributeType`).
@@ -486,15 +486,15 @@ public extension ResourceObjectProxy {
 // MARK: Relationship Access
 public extension ResourceObjectProxy {
 	/// Access to an Id of a `ToOneRelationship`.
-	/// This allows you to write `entity ~> \.other` instead
-	/// of `entity.relationships.other.id`.
+	/// This allows you to write `resourceObject ~> \.other` instead
+	/// of `resourceObject.relationships.other.id`.
 	static func ~><OtherEntity: Identifiable, MType: JSONAPI.Meta, LType: JSONAPI.Links>(entity: Self, path: KeyPath<Description.Relationships, ToOneRelationship<OtherEntity, MType, LType>>) -> OtherEntity.Identifier {
 		return entity.relationships[keyPath: path].id
 	}
 
 	/// Access to an Id of an optional `ToOneRelationship`.
-	/// This allows you to write `entity ~> \.other` instead
-	/// of `entity.relationships.other?.id`.
+	/// This allows you to write `resourceObject ~> \.other` instead
+	/// of `resourceObject.relationships.other?.id`.
 	static func ~><OtherEntity: OptionalRelatable, MType: JSONAPI.Meta, LType: JSONAPI.Links>(entity: Self, path: KeyPath<Description.Relationships, ToOneRelationship<OtherEntity, MType, LType>?>) -> OtherEntity.Identifier {
 		// Implementation Note: This signature applies to `ToOneRelationship<E?, _, _>?`
 		// whereas the one below applies to `ToOneRelationship<E, _, _>?`
@@ -502,8 +502,8 @@ public extension ResourceObjectProxy {
 	}
 
 	/// Access to an Id of an optional `ToOneRelationship`.
-	/// This allows you to write `entity ~> \.other` instead
-	/// of `entity.relationships.other?.id`.
+	/// This allows you to write `resourceObject ~> \.other` instead
+	/// of `resourceObject.relationships.other?.id`.
 	static func ~><OtherEntity: Relatable, MType: JSONAPI.Meta, LType: JSONAPI.Links>(entity: Self, path: KeyPath<Description.Relationships, ToOneRelationship<OtherEntity, MType, LType>?>) -> OtherEntity.Identifier? {
 		// Implementation Note: This signature applies to `ToOneRelationship<E, _, _>?`
 		// whereas the one above applies to `ToOneRelationship<E?, _, _>?`
@@ -511,15 +511,15 @@ public extension ResourceObjectProxy {
 	}
 
 	/// Access to all Ids of a `ToManyRelationship`.
-	/// This allows you to write `entity ~> \.others` instead
-	/// of `entity.relationships.others.ids`.
+	/// This allows you to write `resourceObject ~> \.others` instead
+	/// of `resourceObject.relationships.others.ids`.
 	static func ~><OtherEntity: Relatable, MType: JSONAPI.Meta, LType: JSONAPI.Links>(entity: Self, path: KeyPath<Description.Relationships, ToManyRelationship<OtherEntity, MType, LType>>) -> [OtherEntity.Identifier] {
 		return entity.relationships[keyPath: path].ids
 	}
 
 	/// Access to all Ids of an optional `ToManyRelationship`.
-	/// This allows you to write `entity ~> \.others` instead
-	/// of `entity.relationships.others?.ids`.
+	/// This allows you to write `resourceObject ~> \.others` instead
+	/// of `resourceObject.relationships.others?.ids`.
 	static func ~><OtherEntity: Relatable, MType: JSONAPI.Meta, LType: JSONAPI.Links>(entity: Self, path: KeyPath<Description.Relationships, ToManyRelationship<OtherEntity, MType, LType>?>) -> [OtherEntity.Identifier]? {
 		return entity.relationships[keyPath: path]?.ids
 	}
@@ -528,15 +528,15 @@ public extension ResourceObjectProxy {
 // MARK: Meta-Relationship Access
 public extension ResourceObjectProxy {
 	/// Access to an Id of a `ToOneRelationship`.
-	/// This allows you to write `entity ~> \.other` instead
-	/// of `entity.relationships.other.id`.
+	/// This allows you to write `resourceObject ~> \.other` instead
+	/// of `resourceObject.relationships.other.id`.
 	static func ~><Identifier: IdType>(entity: Self, path: KeyPath<Description.Relationships, (Self) -> Identifier>) -> Identifier {
 		return entity.relationships[keyPath: path](entity)
 	}
 
 	/// Access to all Ids of a `ToManyRelationship`.
-	/// This allows you to write `entity ~> \.others` instead
-	/// of `entity.relationships.others.ids`.
+	/// This allows you to write `resourceObject ~> \.others` instead
+	/// of `resourceObject.relationships.others.ids`.
 	static func ~><Identifier: IdType>(entity: Self, path: KeyPath<Description.Relationships, (Self) -> [Identifier]>) -> [Identifier] {
 		return entity.relationships[keyPath: path](entity)
 	}
@@ -554,11 +554,11 @@ private enum ResourceObjectCodingKeys: String, CodingKey {
 	case links = "links"
 }
 
-public extension Entity {
+public extension ResourceObject {
 	func encode(to encoder: Encoder) throws {
 		var container = encoder.container(keyedBy: ResourceObjectCodingKeys.self)
 		
-		try container.encode(Entity.jsonType, forKey: .type)
+		try container.encode(ResourceObject.jsonType, forKey: .type)
 		
 		if EntityRawIdType.self != Unidentified.self {
 			try container.encode(id, forKey: .id)
@@ -587,12 +587,12 @@ public extension Entity {
 		
 		let type = try container.decode(String.self, forKey: .type)
 		
-		guard Entity.jsonType == type else {
+		guard ResourceObject.jsonType == type else {
 			throw JSONAPIEncodingError.typeMismatch(expected: Description.jsonType, found: type)
 		}
 
 		let maybeUnidentified = Unidentified() as? EntityRawIdType
-		id = try maybeUnidentified.map { Entity.Id(rawValue: $0) } ?? container.decode(Entity.Id.self, forKey: .id)
+		id = try maybeUnidentified.map { ResourceObject.Id(rawValue: $0) } ?? container.decode(ResourceObject.Id.self, forKey: .id)
 
 		attributes = try (NoAttributes() as? Description.Attributes) ??
 			container.decode(Description.Attributes.self, forKey: .attributes)

--- a/Sources/JSONAPITesting/EntityCheck.swift
+++ b/Sources/JSONAPITesting/EntityCheck.swift
@@ -54,8 +54,8 @@ private protocol _AttributeType {}
 extension TransformedAttribute: _AttributeType {}
 extension Attribute: _AttributeType {}
 
-public extension Entity {
-	static func check(_ entity: Entity) throws {
+public extension ResourceObject {
+	static func check(_ entity: ResourceObject) throws {
 		var problems = [EntityCheckError]()
 
 		let attributesMirror = Mirror(reflecting: entity.attributes)

--- a/Sources/JSONAPITesting/ResourceObjectCheck.swift
+++ b/Sources/JSONAPITesting/ResourceObjectCheck.swift
@@ -1,5 +1,5 @@
 //
-//  EntityCheck.swift
+//  ResourceObjectCheck.swift
 //  JSONAPITesting
 //
 //  Created by Mathew Polzin on 11/27/18.
@@ -7,7 +7,7 @@
 
 import JSONAPI
 
-public enum EntityCheckError: Swift.Error {
+public enum ResourceObjectCheckError: Swift.Error {
 	/// The attributes should live in a struct, not
 	/// another type class.
 	case attributesNotStruct
@@ -29,8 +29,8 @@ public enum EntityCheckError: Swift.Error {
 	case nullArray(named: String)
 }
 
-public struct EntityCheckErrors: Swift.Error {
-	let problems: [EntityCheckError]
+public struct ResourceObjectCheckErrors: Swift.Error {
+	let problems: [ResourceObjectCheckError]
 }
 
 private protocol OptionalAttributeType {}
@@ -56,7 +56,7 @@ extension Attribute: _AttributeType {}
 
 public extension ResourceObject {
 	static func check(_ entity: ResourceObject) throws {
-		var problems = [EntityCheckError]()
+		var problems = [ResourceObjectCheckError]()
 
 		let attributesMirror = Mirror(reflecting: entity.attributes)
 
@@ -88,7 +88,7 @@ public extension ResourceObject {
 		}
 
 		guard problems.count == 0 else {
-			throw EntityCheckErrors(problems: problems)
+			throw ResourceObjectCheckErrors(problems: problems)
 		}
 	}
 }

--- a/Tests/JSONAPITestingTests/EntityCheckTests.swift
+++ b/Tests/JSONAPITestingTests/EntityCheckTests.swift
@@ -40,7 +40,7 @@ class EntityCheckTests: XCTestCase {
 
 // MARK: - Test types
 extension EntityCheckTests {
-	enum OkDescription: EntityDescription {
+	enum OkDescription: ResourceObjectDescription {
 		public static var jsonType: String { return "hello" }
 
 		public typealias Attributes = NoAttributes
@@ -49,7 +49,7 @@ extension EntityCheckTests {
 
 	public typealias OkEntity = BasicEntity<OkDescription>
 
-	enum OtherOkDescription: EntityDescription {
+	enum OtherOkDescription: ResourceObjectDescription {
 		public static var jsonType: String { return "hmm" }
 
 		public typealias Attributes = NoAttributes
@@ -58,7 +58,7 @@ extension EntityCheckTests {
 
 	public typealias OtherOkEntity = BasicEntity<OtherOkDescription>
 
-	enum EnumAttributesDescription: EntityDescription {
+	enum EnumAttributesDescription: ResourceObjectDescription {
 		public static var jsonType: String { return "hello" }
 
 		public enum Attributes: JSONAPI.Attributes {
@@ -77,7 +77,7 @@ extension EntityCheckTests {
 
 	public typealias EnumAttributesEntity = BasicEntity<EnumAttributesDescription>
 
-	enum EnumRelationshipsDescription: EntityDescription {
+	enum EnumRelationshipsDescription: ResourceObjectDescription {
 		public static var jsonType: String { return "hello" }
 
 		public typealias Attributes = NoAttributes
@@ -96,7 +96,7 @@ extension EntityCheckTests {
 
 	public typealias EnumRelationshipsEntity = BasicEntity<EnumRelationshipsDescription>
 
-	enum BadAttributeDescription: EntityDescription {
+	enum BadAttributeDescription: ResourceObjectDescription {
 		public static var jsonType: String { return "hello" }
 
 		public struct Attributes: JSONAPI.Attributes {
@@ -109,7 +109,7 @@ extension EntityCheckTests {
 
 	public typealias BadAttributeEntity = BasicEntity<BadAttributeDescription>
 
-	enum BadRelationshipDescription: EntityDescription {
+	enum BadRelationshipDescription: ResourceObjectDescription {
 		public static var jsonType: String { return "hello" }
 
 		public typealias Attributes = NoAttributes
@@ -122,7 +122,7 @@ extension EntityCheckTests {
 
 	public typealias BadRelationshipEntity = BasicEntity<BadRelationshipDescription>
 
-	enum OptionalArrayAttributeDescription: EntityDescription {
+	enum OptionalArrayAttributeDescription: ResourceObjectDescription {
 		public static var jsonType: String { return "hello" }
 
 		public struct Attributes: JSONAPI.Attributes {

--- a/Tests/JSONAPITestingTests/Id+LiteralTests.swift
+++ b/Tests/JSONAPITestingTests/Id+LiteralTests.swift
@@ -24,7 +24,7 @@ class Id_LiteralTests: XCTestCase {
 
 // MARK: - Test types
 extension Id_LiteralTests {
-	enum TestDescription: EntityDescription {
+	enum TestDescription: ResourceObjectDescription {
 		public static var jsonType: String { return "test" }
 
 		public typealias Attributes = NoAttributes

--- a/Tests/JSONAPITestingTests/Relationship+LiteralTests.swift
+++ b/Tests/JSONAPITestingTests/Relationship+LiteralTests.swift
@@ -27,7 +27,7 @@ class Relationship_LiteralTests: XCTestCase {
 
 // MARK: - Test types
 extension Relationship_LiteralTests {
-	enum TestDescription: EntityDescription {
+	enum TestDescription: ResourceObjectDescription {
 		public static var jsonType: String { return "test" }
 
 		public typealias Attributes = NoAttributes

--- a/Tests/JSONAPITestingTests/Test Helpers/EntityTestTypes.swift
+++ b/Tests/JSONAPITestingTests/Test Helpers/EntityTestTypes.swift
@@ -7,8 +7,8 @@
 
 import JSONAPI
 
-public typealias Entity<Description: JSONAPI.EntityDescription, Meta: JSONAPI.Meta, Links: JSONAPI.Links> = JSONAPI.Entity<Description, Meta, Links, String>
+public typealias Entity<Description: JSONAPI.ResourceObjectDescription, Meta: JSONAPI.Meta, Links: JSONAPI.Links> = JSONAPI.Entity<Description, Meta, Links, String>
 
-public typealias BasicEntity<Description: JSONAPI.EntityDescription> = Entity<Description, NoMetadata, NoLinks>
+public typealias BasicEntity<Description: JSONAPI.ResourceObjectDescription> = Entity<Description, NoMetadata, NoLinks>
 
-public typealias NewEntity<Description: JSONAPI.EntityDescription, Meta: JSONAPI.Meta, Links: JSONAPI.Links> = JSONAPI.Entity<Description, Meta, Links, Unidentified>
+public typealias NewEntity<Description: JSONAPI.ResourceObjectDescription, Meta: JSONAPI.Meta, Links: JSONAPI.Links> = JSONAPI.Entity<Description, Meta, Links, Unidentified>

--- a/Tests/JSONAPITestingTests/Test Helpers/EntityTestTypes.swift
+++ b/Tests/JSONAPITestingTests/Test Helpers/EntityTestTypes.swift
@@ -7,8 +7,8 @@
 
 import JSONAPI
 
-public typealias Entity<Description: JSONAPI.ResourceObjectDescription, Meta: JSONAPI.Meta, Links: JSONAPI.Links> = JSONAPI.Entity<Description, Meta, Links, String>
+public typealias Entity<Description: JSONAPI.ResourceObjectDescription, Meta: JSONAPI.Meta, Links: JSONAPI.Links> = JSONAPI.ResourceObject<Description, Meta, Links, String>
 
 public typealias BasicEntity<Description: JSONAPI.ResourceObjectDescription> = Entity<Description, NoMetadata, NoLinks>
 
-public typealias NewEntity<Description: JSONAPI.ResourceObjectDescription, Meta: JSONAPI.Meta, Links: JSONAPI.Links> = JSONAPI.Entity<Description, Meta, Links, Unidentified>
+public typealias NewEntity<Description: JSONAPI.ResourceObjectDescription, Meta: JSONAPI.Meta, Links: JSONAPI.Links> = JSONAPI.ResourceObject<Description, Meta, Links, Unidentified>

--- a/Tests/JSONAPITests/Attribute/Attribute+FunctorTests.swift
+++ b/Tests/JSONAPITests/Attribute/Attribute+FunctorTests.swift
@@ -37,7 +37,7 @@ class Attribute_FunctorTests: XCTestCase {
 
 // MARK: Test types
 extension Attribute_FunctorTests {
-	enum TestTypeDescription: EntityDescription {
+	enum TestTypeDescription: ResourceObjectDescription {
 		public static var jsonType: String { return "test" }
 
 		public struct Attributes: JSONAPI.Attributes {

--- a/Tests/JSONAPITests/Computed Properties/ComputedPropertiesTests.swift
+++ b/Tests/JSONAPITests/Computed Properties/ComputedPropertiesTests.swift
@@ -45,7 +45,7 @@ class ComputedPropertiesTests: XCTestCase {
 
 // MARK: Test types
 extension ComputedPropertiesTests {
-	public enum TestTypeDescription: EntityDescription {
+	public enum TestTypeDescription: ResourceObjectDescription {
 		public static var jsonType: String { return "test" }
 
 		public struct Attributes: JSONAPI.Attributes {

--- a/Tests/JSONAPITests/Custom Attributes Tests/CustomAttributesTests.swift
+++ b/Tests/JSONAPITests/Custom Attributes Tests/CustomAttributesTests.swift
@@ -39,7 +39,7 @@ class CustomAttributesTests: XCTestCase {
 
 // MARK: - Test Types
 extension CustomAttributesTests {
-	enum CustomAttributeEntityDescription: EntityDescription {
+	enum CustomAttributeEntityDescription: ResourceObjectDescription {
 		public static var jsonType: String { return "test1" }
 
 		public struct Attributes: JSONAPI.Attributes {
@@ -57,7 +57,7 @@ extension CustomAttributesTests {
 
 	typealias CustomAttributeEntity = BasicEntity<CustomAttributeEntityDescription>
 
-	enum CustomKeysEntityDescription: EntityDescription {
+	enum CustomKeysEntityDescription: ResourceObjectDescription {
 		public static var jsonType: String { return "test1" }
 
 		public struct Attributes: JSONAPI.Attributes {

--- a/Tests/JSONAPITests/Document/DocumentTests.swift
+++ b/Tests/JSONAPITests/Document/DocumentTests.swift
@@ -1049,11 +1049,11 @@ extension DocumentTests {
 		let entity1 = Article(attributes: .none, relationships: .init(author: "2"), meta: .none, links: .none)
 		let entity2 = Article(attributes: .none, relationships: .init(author: "3"), meta: .none, links: .none)
 
-		let bodyData1 = Document<ManyResourceBody<Article>, NoMetadata, NoLinks, NoIncludes, NoAPIDescription, UnknownJSONAPIError>.Body.Data(primary: .init(entities: [entity1]),
+		let bodyData1 = Document<ManyResourceBody<Article>, NoMetadata, NoLinks, NoIncludes, NoAPIDescription, UnknownJSONAPIError>.Body.Data(primary: .init(resourceObjects: [entity1]),
 																																			  includes: .none,
 																																			  meta: .none,
 																																			  links: .none)
-		let bodyData2 = Document<ManyResourceBody<Article>, NoMetadata, NoLinks, NoIncludes, NoAPIDescription, UnknownJSONAPIError>.Body.Data(primary: .init(entities: [entity2]),
+		let bodyData2 = Document<ManyResourceBody<Article>, NoMetadata, NoLinks, NoIncludes, NoAPIDescription, UnknownJSONAPIError>.Body.Data(primary: .init(resourceObjects: [entity2]),
 																																			  includes: .none,
 																																			  meta: .none,
 																																			  links: .none)
@@ -1068,11 +1068,11 @@ extension DocumentTests {
 		let article2 = Article(attributes: .none, relationships: .init(author: "3"), meta: .none, links: .none)
 		let author2 = Author(id: "3", attributes: .none, relationships: .none, meta: .none, links: .none)
 
-		let bodyData1 = Document<ManyResourceBody<Article>, TestPageMetadata, NoLinks, Include1<Author>, NoAPIDescription, UnknownJSONAPIError>.Body.Data(primary: .init(entities: [article1]),
+		let bodyData1 = Document<ManyResourceBody<Article>, TestPageMetadata, NoLinks, Include1<Author>, NoAPIDescription, UnknownJSONAPIError>.Body.Data(primary: .init(resourceObjects: [article1]),
 																																						  includes: .init(values: [.init(author1)]),
 																																						  meta: .init(total: 50, limit: 5, offset: 5),
 																																						  links: .none)
-		let bodyData2 = Document<ManyResourceBody<Article>, TestPageMetadata, NoLinks, Include1<Author>, NoAPIDescription, UnknownJSONAPIError>.Body.Data(primary: .init(entities: [article2]),
+		let bodyData2 = Document<ManyResourceBody<Article>, TestPageMetadata, NoLinks, Include1<Author>, NoAPIDescription, UnknownJSONAPIError>.Body.Data(primary: .init(resourceObjects: [article2]),
 																																						  includes: .init(values: [.init(author2)]),
 																																						  meta: .init(total: 60, limit: 5, offset: 5),
 																																						  links: .none)

--- a/Tests/JSONAPITests/Document/DocumentTests.swift
+++ b/Tests/JSONAPITests/Document/DocumentTests.swift
@@ -1094,7 +1094,7 @@ extension DocumentTests {
 
 // MARK: - Test Types
 extension DocumentTests {
-	enum AuthorType: EntityDescription {
+	enum AuthorType: ResourceObjectDescription {
 		static var jsonType: String { return "authors" }
 
 		typealias Attributes = NoAttributes
@@ -1103,7 +1103,7 @@ extension DocumentTests {
 
 	typealias Author = BasicEntity<AuthorType>
 	
-	enum ArticleType: EntityDescription {
+	enum ArticleType: ResourceObjectDescription {
 		static var jsonType: String { return "articles" }
 		
 		typealias Attributes = NoAttributes

--- a/Tests/JSONAPITests/Entity/EntityTests.swift
+++ b/Tests/JSONAPITests/Entity/EntityTests.swift
@@ -646,7 +646,7 @@ extension EntityTests {
 // MARK: - Test Types
 extension EntityTests {
 
-	enum TestEntityType1: EntityDescription {
+	enum TestEntityType1: ResourceObjectDescription {
 		static var jsonType: String { return "test_entities"}
 
 		typealias Attributes = NoAttributes
@@ -655,7 +655,7 @@ extension EntityTests {
 
 	typealias TestEntity1 = BasicEntity<TestEntityType1>
 
-	enum TestEntityType2: EntityDescription {
+	enum TestEntityType2: ResourceObjectDescription {
 		static var jsonType: String { return "second_test_entities"}
 
 		typealias Attributes = NoAttributes
@@ -667,7 +667,7 @@ extension EntityTests {
 
 	typealias TestEntity2 = BasicEntity<TestEntityType2>
 
-	enum TestEntityType3: EntityDescription {
+	enum TestEntityType3: ResourceObjectDescription {
 		static var jsonType: String { return "third_test_entities"}
 
 		typealias Attributes = NoAttributes
@@ -679,7 +679,7 @@ extension EntityTests {
 
 	typealias TestEntity3 = BasicEntity<TestEntityType3>
 
-	enum TestEntityType4: EntityDescription {
+	enum TestEntityType4: ResourceObjectDescription {
 		static var jsonType: String { return "fourth_test_entities"}
 
 		struct Relationships: JSONAPI.Relationships {
@@ -701,7 +701,7 @@ extension EntityTests {
 
 	typealias TestEntity4WithMetaAndLinks = Entity<TestEntityType4, TestEntityMeta, TestEntityLinks>
 
-	enum TestEntityType5: EntityDescription {
+	enum TestEntityType5: ResourceObjectDescription {
 		static var jsonType: String { return "fifth_test_entities"}
 
 		typealias Relationships = NoRelationships
@@ -713,7 +713,7 @@ extension EntityTests {
 
 	typealias TestEntity5 = BasicEntity<TestEntityType5>
 
-	enum TestEntityType6: EntityDescription {
+	enum TestEntityType6: ResourceObjectDescription {
 		static var jsonType: String { return "sixth_test_entities" }
 
 		typealias Relationships = NoRelationships
@@ -727,7 +727,7 @@ extension EntityTests {
 
 	typealias TestEntity6 = BasicEntity<TestEntityType6>
 
-	enum TestEntityType7: EntityDescription {
+	enum TestEntityType7: ResourceObjectDescription {
 		static var jsonType: String { return "seventh_test_entities" }
 
 		typealias Relationships = NoRelationships
@@ -740,7 +740,7 @@ extension EntityTests {
 
 	typealias TestEntity7 = BasicEntity<TestEntityType7>
 
-	enum TestEntityType8: EntityDescription {
+	enum TestEntityType8: ResourceObjectDescription {
 		static var jsonType: String { return "eighth_test_entities" }
 
 		typealias Relationships = NoRelationships
@@ -758,7 +758,7 @@ extension EntityTests {
 	
 	typealias TestEntity8 = BasicEntity<TestEntityType8>
 
-	enum TestEntityType9: EntityDescription {
+	enum TestEntityType9: ResourceObjectDescription {
 		public static var jsonType: String { return "ninth_test_entities" }
 
 		typealias Attributes = NoAttributes
@@ -781,7 +781,7 @@ extension EntityTests {
 
 	typealias TestEntity9 = BasicEntity<TestEntityType9>
 
-	enum TestEntityType10: EntityDescription {
+	enum TestEntityType10: ResourceObjectDescription {
 		public static var jsonType: String { return "tenth_test_entities" }
 
 		typealias Attributes = NoAttributes
@@ -794,7 +794,7 @@ extension EntityTests {
 
 	typealias TestEntity10 = BasicEntity<TestEntityType10>
 
-	enum TestEntityType11: EntityDescription {
+	enum TestEntityType11: ResourceObjectDescription {
 		public static var jsonType: String { return "eleventh_test_entities" }
 
 		public struct Attributes: JSONAPI.Attributes {
@@ -806,7 +806,7 @@ extension EntityTests {
 
 	typealias TestEntity11 = BasicEntity<TestEntityType11>
 
-	enum UnidentifiedTestEntityType: EntityDescription {
+	enum UnidentifiedTestEntityType: ResourceObjectDescription {
 		public static var jsonType: String { return "unidentified_test_entities" }
 
 		struct Attributes: JSONAPI.Attributes {
@@ -824,7 +824,7 @@ extension EntityTests {
 
 	typealias UnidentifiedTestEntityWithMetaAndLinks = NewEntity<UnidentifiedTestEntityType, TestEntityMeta, TestEntityLinks>
 
-	enum TestEntityWithMetaAttributeDescription: EntityDescription {
+	enum TestEntityWithMetaAttributeDescription: ResourceObjectDescription {
 		public static var jsonType: String { return "meta_attribute_entity" }
 
 		struct Attributes: JSONAPI.Attributes {
@@ -840,7 +840,7 @@ extension EntityTests {
 
 	typealias TestEntityWithMetaAttribute = BasicEntity<TestEntityWithMetaAttributeDescription>
 
-	enum TestEntityWithMetaRelationshipDescription: EntityDescription {
+	enum TestEntityWithMetaRelationshipDescription: ResourceObjectDescription {
 		public static var jsonType: String { return "meta_relationship_entity" }
 
 		typealias Attributes = NoAttributes

--- a/Tests/JSONAPITests/Entity/EntityTests.swift
+++ b/Tests/JSONAPITests/Entity/EntityTests.swift
@@ -27,7 +27,7 @@ class EntityTests: XCTestCase {
 
 	func test_optional_relationship_operator_access() {
 		let entity1 = TestEntity1(attributes: .none, relationships: .none, meta: .none, links: .none)
-		let entity = TestEntity9(attributes: .none, relationships: .init(one: entity1.pointer, nullableOne: .init(entity: entity1, meta: .none, links: .none), optionalOne: .init(entity: entity1, meta: .none, links: .none), optionalNullableOne: nil, optionalMany: .init(entities: [entity1, entity1], meta: .none, links: .none)), meta: .none, links: .none)
+		let entity = TestEntity9(attributes: .none, relationships: .init(one: entity1.pointer, nullableOne: .init(resourceObject: entity1, meta: .none, links: .none), optionalOne: .init(resourceObject: entity1, meta: .none, links: .none), optionalNullableOne: nil, optionalMany: .init(resourceObjects: [entity1, entity1], meta: .none, links: .none)), meta: .none, links: .none)
 
 		XCTAssertEqual(entity ~> \.optionalOne, entity1.id)
 	}
@@ -43,7 +43,7 @@ class EntityTests: XCTestCase {
 
 	func test_optionalToMany_relationship_opeartor_access() {
 		let entity1 = TestEntity1(attributes: .none, relationships: .none, meta: .none, links: .none)
-		let entity = TestEntity9(attributes: .none, relationships: .init(one: entity1.pointer, nullableOne: .init(entity: entity1, meta: .none, links: .none), optionalOne: nil, optionalNullableOne: nil, optionalMany: .init(entities: [entity1, entity1], meta: .none, links: .none)), meta: .none, links: .none)
+		let entity = TestEntity9(attributes: .none, relationships: .init(one: entity1.pointer, nullableOne: .init(resourceObject: entity1, meta: .none, links: .none), optionalOne: nil, optionalNullableOne: nil, optionalMany: .init(resourceObjects: [entity1, entity1], meta: .none, links: .none)), meta: .none, links: .none)
 
 		XCTAssertEqual(entity ~> \.optionalMany, [entity1.id, entity1.id])
 	}
@@ -73,9 +73,9 @@ class EntityTests: XCTestCase {
 
 	func test_initialization() {
 		let entity1 = TestEntity1(id: .init(rawValue: "wow"), attributes: .none, relationships: .none, meta: .none, links: .none)
-		let entity2 = TestEntity2(id: .init(rawValue: "cool"), attributes: .none, relationships: .init(other: .init(entity: entity1)), meta: .none, links: .none)
-		let _ = TestEntity2(id: .init(rawValue: "cool"), attributes: .none, relationships: .init(other: .init(entity: entity1)), meta: .none, links: .none)
-		let _ = TestEntity2(id: .init(rawValue: "cool"), attributes: .none, relationships: .init(other: .init(entity: entity1)), meta: .none, links: .none)
+		let entity2 = TestEntity2(id: .init(rawValue: "cool"), attributes: .none, relationships: .init(other: .init(resourceObject: entity1)), meta: .none, links: .none)
+		let _ = TestEntity2(id: .init(rawValue: "cool"), attributes: .none, relationships: .init(other: .init(resourceObject: entity1)), meta: .none, links: .none)
+		let _ = TestEntity2(id: .init(rawValue: "cool"), attributes: .none, relationships: .init(other: .init(resourceObject: entity1)), meta: .none, links: .none)
 		let _ = TestEntity3(id: .init(rawValue: "3"), attributes: .none, relationships: .init(others: .init(ids: [.init(rawValue: "10"), .init(rawValue: "20"), entity1.id])), meta: .none, links: .none)
 		let _ = TestEntity3(id: .init(rawValue: "3"), attributes: .none, relationships: .init(others: .none), meta: .none, links: .none)
 		let _ = TestEntity4(id: .init(rawValue: "4"), attributes: .init(word: .init(value: "hello"), number: .init(value: 10), array: .init(value: [10.2, 10.3])), relationships: .init(other: entity2.pointer), meta: .none, links: .none)
@@ -84,12 +84,12 @@ class EntityTests: XCTestCase {
 		let _ = TestEntity7(id: .init(rawValue: "7"), attributes: .init(here: .init(value: "hello"), maybeHereMaybeNull: .init(value: "world")), relationships: .none, meta: .none, links: .none)
 		XCTAssertNoThrow(try TestEntity8(id: .init(rawValue: "8"), attributes: .init(string: .init(value: "hello"), int: .init(value: 10), stringFromInt: .init(rawValue: 20), plus: .init(rawValue: 30), doubleFromInt: .init(rawValue: 32), omitted: nil, nullToString: .init(rawValue: nil)), relationships: .none, meta: .none, links: .none))
 		let _ = TestEntity9(id: .init(rawValue: "9"), attributes: .none, relationships: .init(one: entity1.pointer, nullableOne: nil, optionalOne: nil, optionalNullableOne: nil, optionalMany: nil), meta: .none, links: .none)
-		let _ = TestEntity9(id: .init(rawValue: "9"), attributes: .none, relationships: .init(one: entity1.pointer, nullableOne: .init(entity: nil), optionalOne: nil, optionalNullableOne: nil, optionalMany: nil), meta: .none, links: .none)
+		let _ = TestEntity9(id: .init(rawValue: "9"), attributes: .none, relationships: .init(one: entity1.pointer, nullableOne: .init(resourceObject: nil), optionalOne: nil, optionalNullableOne: nil, optionalMany: nil), meta: .none, links: .none)
 		let _ = TestEntity9(id: .init(rawValue: "9"), attributes: .none, relationships: .init(one: entity1.pointer, nullableOne: .init(id: nil), optionalOne: nil, optionalNullableOne: nil, optionalMany: nil), meta: .none, links: .none)
-		let _ = TestEntity9(id: .init(rawValue: "9"), attributes: .none, relationships: .init(one: entity1.pointer, nullableOne: .init(entity: entity1, meta: .none, links: .none), optionalOne: nil, optionalNullableOne: nil, optionalMany: nil), meta: .none, links: .none)
+		let _ = TestEntity9(id: .init(rawValue: "9"), attributes: .none, relationships: .init(one: entity1.pointer, nullableOne: .init(resourceObject: entity1, meta: .none, links: .none), optionalOne: nil, optionalNullableOne: nil, optionalMany: nil), meta: .none, links: .none)
 		let _ = TestEntity9(id: .init(rawValue: "9"), attributes: .none, relationships: .init(one: entity1.pointer, nullableOne: nil, optionalOne: entity1.pointer, optionalNullableOne: nil, optionalMany: nil), meta: .none, links: .none)
-		let _ = TestEntity9(id: .init(rawValue: "9"), attributes: .none, relationships: .init(one: entity1.pointer, nullableOne: nil, optionalOne: nil, optionalNullableOne: .init(entity: entity1, meta: .none, links: .none), optionalMany: nil), meta: .none, links: .none)
-		let _ = TestEntity9(id: .init(rawValue: "9"), attributes: .none, relationships: .init(one: entity1.pointer, nullableOne: nil, optionalOne: nil, optionalNullableOne: .init(entity: entity1, meta: .none, links: .none), optionalMany: .init(entities: [], meta: .none, links: .none)), meta: .none, links: .none)
+		let _ = TestEntity9(id: .init(rawValue: "9"), attributes: .none, relationships: .init(one: entity1.pointer, nullableOne: nil, optionalOne: nil, optionalNullableOne: .init(resourceObject: entity1, meta: .none, links: .none), optionalMany: nil), meta: .none, links: .none)
+		let _ = TestEntity9(id: .init(rawValue: "9"), attributes: .none, relationships: .init(one: entity1.pointer, nullableOne: nil, optionalOne: nil, optionalNullableOne: .init(resourceObject: entity1, meta: .none, links: .none), optionalMany: .init(resourceObjects: [], meta: .none, links: .none)), meta: .none, links: .none)
 		let e10id1 = TestEntity10.Identifier(rawValue: "hello")
 		let e10id2 = TestEntity10.Id(rawValue: "world")
 		let e10id3: TestEntity10.Id = "!"

--- a/Tests/JSONAPITests/Includes/IncludeTests.swift
+++ b/Tests/JSONAPITests/Includes/IncludeTests.swift
@@ -192,7 +192,7 @@ extension IncludedTests {
 
 // MARK: - Test types
 extension IncludedTests {
-	enum TestEntityType: EntityDescription {
+	enum TestEntityType: ResourceObjectDescription {
 
 		typealias Relationships = NoRelationships
 
@@ -206,7 +206,7 @@ extension IncludedTests {
 
 	typealias TestEntity = BasicEntity<TestEntityType>
 
-	enum TestEntityType2: EntityDescription {
+	enum TestEntityType2: ResourceObjectDescription {
 
 		public static var jsonType: String { return "test_entity2" }
 
@@ -222,7 +222,7 @@ extension IncludedTests {
 
 	typealias TestEntity2 = BasicEntity<TestEntityType2>
 
-	enum TestEntityType3: EntityDescription {
+	enum TestEntityType3: ResourceObjectDescription {
 
 		typealias Attributes = NoAttributes
 		
@@ -236,7 +236,7 @@ extension IncludedTests {
 
 	typealias TestEntity3 = BasicEntity<TestEntityType3>
 
-	enum TestEntityType4: EntityDescription {
+	enum TestEntityType4: ResourceObjectDescription {
 
 		typealias Attributes = NoAttributes
 
@@ -247,7 +247,7 @@ extension IncludedTests {
 
 	typealias TestEntity4 = BasicEntity<TestEntityType4>
 
-	enum TestEntityType5: EntityDescription {
+	enum TestEntityType5: ResourceObjectDescription {
 
 		typealias Attributes = NoAttributes
 
@@ -258,7 +258,7 @@ extension IncludedTests {
 
 	typealias TestEntity5 = BasicEntity<TestEntityType5>
 
-	enum TestEntityType6: EntityDescription {
+	enum TestEntityType6: ResourceObjectDescription {
 
 		typealias Attributes = NoAttributes
 
@@ -271,7 +271,7 @@ extension IncludedTests {
 
 	typealias TestEntity6 = BasicEntity<TestEntityType6>
 
-	enum TestEntityType7: EntityDescription {
+	enum TestEntityType7: ResourceObjectDescription {
 
 		typealias Attributes = NoAttributes
 
@@ -282,7 +282,7 @@ extension IncludedTests {
 
 	typealias TestEntity7 = BasicEntity<TestEntityType7>
 
-	enum TestEntityType8: EntityDescription {
+	enum TestEntityType8: ResourceObjectDescription {
 
 		typealias Attributes = NoAttributes
 
@@ -293,7 +293,7 @@ extension IncludedTests {
 
 	typealias TestEntity8 = BasicEntity<TestEntityType8>
 
-	enum TestEntityType9: EntityDescription {
+	enum TestEntityType9: ResourceObjectDescription {
 
 		typealias Attributes = NoAttributes
 

--- a/Tests/JSONAPITests/NonJSONAPIRelatable/NonJSONAPIRelatableTests.swift
+++ b/Tests/JSONAPITests/NonJSONAPIRelatable/NonJSONAPIRelatableTests.swift
@@ -63,7 +63,7 @@ extension NonJSONAPIRelatableTests {
 		}
 	}
 
-	typealias TestEntity = JSONAPI.Entity<TestEntityDescription, NoMetadata, NoLinks, String>
+	typealias TestEntity = JSONAPI.ResourceObject<TestEntityDescription, NoMetadata, NoLinks, String>
 
 	enum TestEntity2Description: ResourceObjectDescription {
 		static var jsonType: String { return "test" }
@@ -78,7 +78,7 @@ extension NonJSONAPIRelatableTests {
 		}
 	}
 
-	typealias TestEntity2 = JSONAPI.Entity<TestEntity2Description, NoMetadata, NoLinks, String>
+	typealias TestEntity2 = JSONAPI.ResourceObject<TestEntity2Description, NoMetadata, NoLinks, String>
 
 	struct NonJSONAPIEntity: Relatable, JSONTyped {
 		static var jsonType: String { return "other" }

--- a/Tests/JSONAPITests/NonJSONAPIRelatable/NonJSONAPIRelatableTests.swift
+++ b/Tests/JSONAPITests/NonJSONAPIRelatable/NonJSONAPIRelatableTests.swift
@@ -52,7 +52,7 @@ class NonJSONAPIRelatableTests: XCTestCase {
 
 // MARK: - Test Types
 extension NonJSONAPIRelatableTests {
-	enum TestEntityDescription: EntityDescription {
+	enum TestEntityDescription: ResourceObjectDescription {
 		static var jsonType: String { return "test" }
 
 		typealias Attributes = NoAttributes
@@ -65,7 +65,7 @@ extension NonJSONAPIRelatableTests {
 
 	typealias TestEntity = JSONAPI.Entity<TestEntityDescription, NoMetadata, NoLinks, String>
 
-	enum TestEntity2Description: EntityDescription {
+	enum TestEntity2Description: ResourceObjectDescription {
 		static var jsonType: String { return "test" }
 
 		typealias Attributes = NoAttributes

--- a/Tests/JSONAPITests/Poly/PolyProxyTests.swift
+++ b/Tests/JSONAPITests/Poly/PolyProxyTests.swift
@@ -92,7 +92,7 @@ public extension PolyProxyTests {
 	typealias User = Poly2<UserA, UserB>
 }
 
-extension Poly2: EntityProxy, JSONTyped where A == PolyProxyTests.UserA, B == PolyProxyTests.UserB {
+extension Poly2: ResourceObjectProxy, JSONTyped where A == PolyProxyTests.UserA, B == PolyProxyTests.UserB {
 
 	public var userA: PolyProxyTests.UserA? {
 		return a

--- a/Tests/JSONAPITests/Poly/PolyProxyTests.swift
+++ b/Tests/JSONAPITests/Poly/PolyProxyTests.swift
@@ -65,7 +65,7 @@ public class PolyProxyTests: XCTestCase {
 
 // MARK: - Test types
 public extension PolyProxyTests {
-	enum UserDescription1: EntityDescription {
+	enum UserDescription1: ResourceObjectDescription {
 		public static var jsonType: String { return "users" }
 
 		public struct Attributes: JSONAPI.Attributes {
@@ -76,7 +76,7 @@ public extension PolyProxyTests {
 		public typealias Relationships = NoRelationships
 	}
 
-	enum UserDescription2: EntityDescription {
+	enum UserDescription2: ResourceObjectDescription {
 		public static var jsonType: String { return "users" }
 
 		public struct Attributes: JSONAPI.Attributes {
@@ -124,7 +124,7 @@ extension Poly2: EntityProxy, JSONTyped where A == PolyProxyTests.UserA, B == Po
 		return .none
 	}
 
-	public enum SharedUserDescription: EntityProxyDescription {
+	public enum SharedUserDescription: ResourceObjectProxyDescription {
 		public static var jsonType: String { return A.jsonType }
 
 		public struct Attributes: Equatable {

--- a/Tests/JSONAPITests/Poly/PolyTests.swift
+++ b/Tests/JSONAPITests/Poly/PolyTests.swift
@@ -569,7 +569,7 @@ extension PolyTests {
 
 // MARK: - Test types
 extension PolyTests {
-	enum TestEntityType: EntityDescription {
+	enum TestEntityType: ResourceObjectDescription {
 
 		typealias Relationships = NoRelationships
 
@@ -583,7 +583,7 @@ extension PolyTests {
 
 	typealias TestEntity = BasicEntity<TestEntityType>
 
-	enum TestEntityType2: EntityDescription {
+	enum TestEntityType2: ResourceObjectDescription {
 
 		public static var jsonType: String { return "test_entity2" }
 
@@ -599,7 +599,7 @@ extension PolyTests {
 
 	typealias TestEntity2 = BasicEntity<TestEntityType2>
 
-	enum TestEntityType3: EntityDescription {
+	enum TestEntityType3: ResourceObjectDescription {
 
 		typealias Attributes = NoAttributes
 
@@ -613,7 +613,7 @@ extension PolyTests {
 
 	typealias TestEntity3 = BasicEntity<TestEntityType3>
 
-	enum TestEntityType4: EntityDescription {
+	enum TestEntityType4: ResourceObjectDescription {
 
 		typealias Attributes = NoAttributes
 
@@ -624,7 +624,7 @@ extension PolyTests {
 
 	typealias TestEntity4 = BasicEntity<TestEntityType4>
 
-	enum TestEntityType5: EntityDescription {
+	enum TestEntityType5: ResourceObjectDescription {
 
 		typealias Attributes = NoAttributes
 
@@ -635,7 +635,7 @@ extension PolyTests {
 
 	typealias TestEntity5 = BasicEntity<TestEntityType5>
 
-	enum TestEntityType6: EntityDescription {
+	enum TestEntityType6: ResourceObjectDescription {
 
 		typealias Attributes = NoAttributes
 
@@ -648,7 +648,7 @@ extension PolyTests {
 
 	typealias TestEntity6 = BasicEntity<TestEntityType6>
 
-	enum TestEntityType7: EntityDescription {
+	enum TestEntityType7: ResourceObjectDescription {
 
 		typealias Attributes = NoAttributes
 
@@ -659,7 +659,7 @@ extension PolyTests {
 
 	typealias TestEntity7 = BasicEntity<TestEntityType7>
 
-	enum TestEntityType8: EntityDescription {
+	enum TestEntityType8: ResourceObjectDescription {
 
 		typealias Attributes = NoAttributes
 
@@ -670,7 +670,7 @@ extension PolyTests {
 
 	typealias TestEntity8 = BasicEntity<TestEntityType8>
 
-	enum TestEntityType9: EntityDescription {
+	enum TestEntityType9: ResourceObjectDescription {
 
 		typealias Attributes = NoAttributes
 

--- a/Tests/JSONAPITests/Relationships/RelationshipTests.swift
+++ b/Tests/JSONAPITests/Relationships/RelationshipTests.swift
@@ -15,7 +15,7 @@ class RelationshipTests: XCTestCase {
 		let entity2 = TestEntity1(attributes: .none, relationships: .none, meta: .none, links: .none)
 		let entity3 = TestEntity1(attributes: .none, relationships: .none, meta: .none, links: .none)
 		let entity4 = TestEntity1(attributes: .none, relationships: .none, meta: .none, links: .none)
-		let relationship = ToManyRelationship<TestEntity1, NoMetadata, NoLinks>(entities: [entity1, entity2, entity3, entity4])
+		let relationship = ToManyRelationship<TestEntity1, NoMetadata, NoLinks>(resourceObjects: [entity1, entity2, entity3, entity4])
 
 		XCTAssertEqual(relationship.ids.count, 4)
 		XCTAssertEqual(relationship.ids, [entity1, entity2, entity3, entity4].map { $0.id })
@@ -143,7 +143,7 @@ extension RelationshipTests {
 // MARK: Nullable
 extension RelationshipTests {
 	func test_ToOneNullableIsNullIfNil() {
-		let relationship = ToOneNullable(entity: nil)
+		let relationship = ToOneNullable(resourceObject: nil)
 		let relationshipData = try! JSONEncoder().encode(relationship)
 		let relationshipString = String(data: relationshipData, encoding: .utf8)!
 
@@ -152,8 +152,8 @@ extension RelationshipTests {
 
 	func test_ToOneNullableIsEqualToNonNullableIfNotNil() {
 		let entity = TestEntity1(attributes: .none, relationships: .none, meta: .none, links: .none)
-		let relationship1 = ToOneNonNullable(entity: entity)
-		let relationship2 = ToOneNullable(entity: entity)
+		let relationship1 = ToOneNonNullable(resourceObject: entity)
+		let relationship2 = ToOneNullable(resourceObject: entity)
 
 		XCTAssertEqual(encoded(value: relationship1), encoded(value: relationship2))
 	}

--- a/Tests/JSONAPITests/Relationships/RelationshipTests.swift
+++ b/Tests/JSONAPITests/Relationships/RelationshipTests.swift
@@ -172,7 +172,7 @@ extension RelationshipTests {
 
 // MARK: - Test types
 extension RelationshipTests {
-	enum TestEntityType1: EntityDescription {
+	enum TestEntityType1: ResourceObjectDescription {
 		typealias Attributes = NoAttributes
 
 		typealias Relationships = NoRelationships

--- a/Tests/JSONAPITests/ResourceBody/ResourceBodyTests.swift
+++ b/Tests/JSONAPITests/ResourceBody/ResourceBodyTests.swift
@@ -15,8 +15,8 @@ class ResourceBodyTests: XCTestCase {
 			Article(attributes: .init(title: "hello"), relationships: .none, meta: .none, links: .none),
 			Article(attributes: .init(title: "world"), relationships: .none, meta: .none, links: .none)
 		]
-		let _ = SingleResourceBody(entity: articles[0])
-		let _ = ManyResourceBody(entities: articles)
+		let _ = SingleResourceBody(resourceObject: articles[0])
+		let _ = ManyResourceBody(resourceObjects: articles)
 		let _: NoResourceBody = .none
 	}
 
@@ -77,7 +77,7 @@ class ResourceBodyTests: XCTestCase {
 	}
 
 	func test_manyResourceBodyMerge() {
-		let body1 = ManyResourceBody(entities: [
+		let body1 = ManyResourceBody(resourceObjects: [
 			Article(attributes: .init(title: "hello"),
 					relationships: .none,
 					meta: .none,
@@ -88,7 +88,7 @@ class ResourceBodyTests: XCTestCase {
 					links: .none)
 			])
 
-		let body2 = ManyResourceBody(entities: [
+		let body2 = ManyResourceBody(resourceObjects: [
 			Article(attributes: .init(title: "once more"),
 					relationships: .none,
 					meta: .none,

--- a/Tests/JSONAPITests/ResourceBody/ResourceBodyTests.swift
+++ b/Tests/JSONAPITests/ResourceBody/ResourceBodyTests.swift
@@ -101,7 +101,7 @@ class ResourceBodyTests: XCTestCase {
 		XCTAssertEqual(combined.values, body1.values + body2.values)
 	}
 
-	enum ArticleType: EntityDescription {
+	enum ArticleType: ResourceObjectDescription {
 		public static var jsonType: String { return "articles" }
 
 		typealias Relationships = NoRelationships

--- a/Tests/JSONAPITests/Test Helpers/EncodedEntityPropertyTest.swift
+++ b/Tests/JSONAPITests/Test Helpers/EncodedEntityPropertyTest.swift
@@ -10,7 +10,7 @@ import XCTest
 import JSONAPI
 import JSONAPITesting
 
-func testEncoded<E: EntityType>(entity: E) {
+func testEncoded<E: ResourceObjectType>(entity: E) {
 	let encodedEntityData = encoded(value: entity)
 	let jsonObject = try! JSONSerialization.jsonObject(with: encodedEntityData, options: [])
 	let jsonDict = jsonObject as? [String: Any]

--- a/Tests/JSONAPITests/Test Helpers/EntityTestTypes.swift
+++ b/Tests/JSONAPITests/Test Helpers/EntityTestTypes.swift
@@ -7,8 +7,8 @@
 
 import JSONAPI
 
-public typealias Entity<Description: JSONAPI.EntityDescription, Meta: JSONAPI.Meta, Links: JSONAPI.Links> = JSONAPI.Entity<Description, Meta, Links, String>
+public typealias Entity<Description: JSONAPI.ResourceObjectDescription, Meta: JSONAPI.Meta, Links: JSONAPI.Links> = JSONAPI.Entity<Description, Meta, Links, String>
 
-public typealias BasicEntity<Description: JSONAPI.EntityDescription> = Entity<Description, NoMetadata, NoLinks>
+public typealias BasicEntity<Description: JSONAPI.ResourceObjectDescription> = Entity<Description, NoMetadata, NoLinks>
 
-public typealias NewEntity<Description: JSONAPI.EntityDescription, Meta: JSONAPI.Meta, Links: JSONAPI.Links> = JSONAPI.Entity<Description, Meta, Links, Unidentified>
+public typealias NewEntity<Description: JSONAPI.ResourceObjectDescription, Meta: JSONAPI.Meta, Links: JSONAPI.Links> = JSONAPI.Entity<Description, Meta, Links, Unidentified>

--- a/Tests/JSONAPITests/Test Helpers/EntityTestTypes.swift
+++ b/Tests/JSONAPITests/Test Helpers/EntityTestTypes.swift
@@ -7,8 +7,8 @@
 
 import JSONAPI
 
-public typealias Entity<Description: JSONAPI.ResourceObjectDescription, Meta: JSONAPI.Meta, Links: JSONAPI.Links> = JSONAPI.Entity<Description, Meta, Links, String>
+public typealias Entity<Description: JSONAPI.ResourceObjectDescription, Meta: JSONAPI.Meta, Links: JSONAPI.Links> = JSONAPI.ResourceObject<Description, Meta, Links, String>
 
 public typealias BasicEntity<Description: JSONAPI.ResourceObjectDescription> = Entity<Description, NoMetadata, NoLinks>
 
-public typealias NewEntity<Description: JSONAPI.ResourceObjectDescription, Meta: JSONAPI.Meta, Links: JSONAPI.Links> = JSONAPI.Entity<Description, Meta, Links, Unidentified>
+public typealias NewEntity<Description: JSONAPI.ResourceObjectDescription, Meta: JSONAPI.Meta, Links: JSONAPI.Links> = JSONAPI.ResourceObject<Description, Meta, Links, Unidentified>


### PR DESCRIPTION
Pretty large renaming effort to better align the type names in this library with the names used by the JSON:API Spec. I think this will ultimately make it much easier to adopt this library given prior knowledge of the Spec. There are no substantive feature changes here, just renaming.