### PR TITLE
Feature/basic error

### DIFF
--- a/JSONAPI.playground/Pages/Full Client & Server Example.xcplaygroundpage/Contents.swift
+++ b/JSONAPI.playground/Pages/Full Client & Server Example.xcplaygroundpage/Contents.swift
@@ -37,7 +37,7 @@ typealias ToManyRelationship<Entity: Relatable> = JSONAPI.ToManyRelationship<Ent
 // JSON:API Documents for this particular API to have Metadata, Links,
 // useful Errors, or an APIDescription (The *SPEC* calls this
 // "API Description" the "JSON:API Object").
-typealias Document<PrimaryResourceBody: JSONAPI.ResourceBody, IncludeType: JSONAPI.Include> = JSONAPI.Document<PrimaryResourceBody, NoMetadata, NoLinks, IncludeType, NoAPIDescription, UnknownJSONAPIError>
+typealias Document<PrimaryResourceBody: JSONAPI.ResourceBody, IncludeType: JSONAPI.Include> = JSONAPI.Document<PrimaryResourceBody, NoMetadata, NoLinks, IncludeType, NoAPIDescription, BasicJSONAPIError<String>>
 
 // MARK: Entity Definitions
 

--- a/JSONAPI.playground/Pages/Sparse Fieldsets Example.xcplaygroundpage/Contents.swift
+++ b/JSONAPI.playground/Pages/Sparse Fieldsets Example.xcplaygroundpage/Contents.swift
@@ -35,7 +35,7 @@ typealias ThingWithProperties = JSONAPI.ResourceObject<ThingWithPropertiesDescri
 //
 // NOTE: Using `JSONAPI.EncodableResourceBody` which means the document type will be `Encodable` but not `Decodable`.
 //
-typealias Document<PrimaryResourceBody: JSONAPI.EncodableResourceBody, IncludeType: JSONAPI.Include> = JSONAPI.Document<PrimaryResourceBody, NoMetadata, NoLinks, IncludeType, NoAPIDescription, UnknownJSONAPIError>
+typealias Document<PrimaryResourceBody: JSONAPI.EncodableResourceBody, IncludeType: JSONAPI.Include> = JSONAPI.Document<PrimaryResourceBody, NoMetadata, NoLinks, IncludeType, NoAPIDescription, BasicJSONAPIError<String>>
 
 //
 // NOTE: Using `JSONAPI.EncodablePrimaryResource` which means the `ResourceBody` will be `Encodable` but not `Decodable.

--- a/JSONAPI.playground/Sources/Entities.swift
+++ b/JSONAPI.playground/Sources/Entities.swift
@@ -139,6 +139,6 @@ public enum HouseDescription: ResourceObjectDescription {
 
 public typealias House = ExampleEntity<HouseDescription>
 
-public typealias SingleDogDocument = JSONAPI.Document<SingleResourceBody<Dog>, NoMetadata, NoLinks, NoIncludes, NoAPIDescription, UnknownJSONAPIError>
+public typealias SingleDogDocument = JSONAPI.Document<SingleResourceBody<Dog>, NoMetadata, NoLinks, NoIncludes, NoAPIDescription, BasicJSONAPIError<String>>
 
-public typealias BatchPeopleDocument = JSONAPI.Document<ManyResourceBody<Person>, NoMetadata, NoLinks, Include2<Dog, House>, NoAPIDescription, UnknownJSONAPIError>
+public typealias BatchPeopleDocument = JSONAPI.Document<ManyResourceBody<Person>, NoMetadata, NoLinks, Include2<Dog, House>, NoAPIDescription, BasicJSONAPIError<String>>

--- a/JSONAPI.podspec
+++ b/JSONAPI.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "MP-JSONAPI"
-  spec.version      = "2.1.0"
+  spec.version      = "2.2.0"
   spec.summary      = "Swift Codable JSON API framework."
 
   # This description is used to generate tags and improve search results.

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ See the JSON API Spec here: https://jsonapi.org/format/
 ## Quick Start
 
 ### Clientside
-- [Basic Example](https://colab.research.google.com/drive/1IS7lRSBGoiW02Vd1nN_rfdDbZvTDj6Te) 
-- [Compound Example](https://colab.research.google.com/drive/1BdF0Kc7l2ixDfBZEL16FY6palweDszQU) 
-- [Metadata Example](https://colab.research.google.com/drive/10dEESwiE9I3YoyfzVeOVwOKUTEgLT3qr) 
+- [Basic Example](https://colab.research.google.com/drive/1IS7lRSBGoiW02Vd1nN_rfdDbZvTDj6Te)
+- [Compound Example](https://colab.research.google.com/drive/1BdF0Kc7l2ixDfBZEL16FY6palweDszQU)
+- [Metadata Example](https://colab.research.google.com/drive/10dEESwiE9I3YoyfzVeOVwOKUTEgLT3qr)
 - [Errors Example](https://colab.research.google.com/drive/1TIv6STzlHrkTf_-9Eu8sv8NoaxhZcFZH)
 
 ### Serverside
@@ -108,7 +108,7 @@ If you find something wrong with this library and it isn't already mentioned und
 ### Swift Package Manager
 Just include the following in your package's dependencies and add `JSONAPI` to the dependencies for any of your targets.
 ```
-	.package(url: "https://github.com/mattpolzin/JSONAPI.git", .upToNextMajor(from: "2.0.0"))
+	.package(url: "https://github.com/mattpolzin/JSONAPI.git", .upToNextMajor(from: "2.2.0"))
 ```
 
 ### CocoaPods

--- a/Sources/JSONAPI/Error/BasicJSONAPIError.swift
+++ b/Sources/JSONAPI/Error/BasicJSONAPIError.swift
@@ -5,30 +5,48 @@
 //  Created by Mathew Polzin on 9/29/19.
 //
 
-import Foundation
-
 /// Most of the JSON:API Spec defined Error fields.
 public struct BasicJSONAPIErrorPayload<IdType: Codable & Equatable>: Codable, Equatable, ErrorDictType {
     /// a unique identifier for this particular occurrence of the problem
-    let id: IdType?
-//    let links: Links? // we skip this for now to avoid adding complexity to using this basic type.
+    public let id: IdType?
+//    public let links: Links? // we skip this for now to avoid adding complexity to using this basic type.
     /// the HTTP status code applicable to this problem
-    let status: String?
+    public let status: String?
     /// an application-specific error code
-    let code: String?
+    public let code: String?
     /// a short, human-readable summary of the problem that SHOULD NOT change from occurrence to occurrence of the problem, except for purposes of localization
-    let title: String?
+    public let title: String?
     /// a human-readable explanation specific to this occurrence of the problem. Like `title`, this field’s value can be localized
-    let detail: String?
+    public let detail: String?
     /// an object containing references to the source of the error
-    let source: Source?
-//    let meta: Meta? // we skip this for now to avoid adding complexity to using this basic type
+    public let source: Source?
+//    public let meta: Meta? // we skip this for now to avoid adding complexity to using this basic type
+
+    public init(id: IdType? = nil,
+                status: String? = nil,
+                code: String? = nil,
+                title: String? = nil,
+                detail: String? = nil,
+                source: Source? = nil) {
+        self.id = id
+        self.status = status
+        self.code = code
+        self.title = title
+        self.detail = detail
+        self.source = source
+    }
 
     public struct Source: Codable, Equatable {
         /// a JSON Pointer [RFC6901] to the associated entity in the request document [e.g. "/data" for a primary data object, or "/data/attributes/title" for a specific attribute].
-        let pointer: String?
+        public let pointer: String?
         /// which URI query parameter caused the error
-        let parameter: String?
+        public let parameter: String?
+
+        public init(pointer: String? = nil,
+                    parameter: String? = nil) {
+            self.pointer = pointer
+            self.parameter = parameter
+        }
     }
 
     public var definedFields: [String: String] {

--- a/Sources/JSONAPI/Error/BasicJSONAPIError.swift
+++ b/Sources/JSONAPI/Error/BasicJSONAPIError.swift
@@ -70,4 +70,9 @@ public struct BasicJSONAPIErrorPayload<IdType: Codable & Equatable>: Codable, Eq
 /// a good option if you do not know what to expect. You could also use
 /// `Either<Int, String>` (provided by the `Poly` package that is
 /// already a dependency of `JSONAPI`).
+///
+///  - Important: The `definedFields` property will include fields
+///     with non-nil values in a flattened way. There will be no `source` key
+///     but there will be `pointer` and `parameter` keys (if those values
+///     are non-nil).
 public typealias BasicJSONAPIError<IdType: Codable & Equatable> = GenericJSONAPIError<BasicJSONAPIErrorPayload<IdType>>

--- a/Sources/JSONAPI/Error/BasicJSONAPIError.swift
+++ b/Sources/JSONAPI/Error/BasicJSONAPIError.swift
@@ -1,0 +1,73 @@
+//
+//  BasicError.swift
+//  JSONAPI
+//
+//  Created by Mathew Polzin on 9/29/19.
+//
+
+import Foundation
+
+/// Most of the JSON:API Spec defined Error fields.
+public struct BasicJSONAPIErrorPayload<IdType: Codable & Equatable>: Codable, Equatable, ErrorDictType {
+    /// a unique identifier for this particular occurrence of the problem
+    let id: IdType?
+//    let links: Links? // we skip this for now to avoid adding complexity to using this basic type.
+    /// the HTTP status code applicable to this problem
+    let status: String?
+    /// an application-specific error code
+    let code: String?
+    /// a short, human-readable summary of the problem that SHOULD NOT change from occurrence to occurrence of the problem, except for purposes of localization
+    let title: String?
+    /// a human-readable explanation specific to this occurrence of the problem. Like `title`, this field’s value can be localized
+    let detail: String?
+    /// an object containing references to the source of the error
+    let source: Source?
+//    let meta: Meta? // we skip this for now to avoid adding complexity to using this basic type
+
+    public struct Source: Codable, Equatable {
+        /// a JSON Pointer [RFC6901] to the associated entity in the request document [e.g. "/data" for a primary data object, or "/data/attributes/title" for a specific attribute].
+        let pointer: String?
+        /// which URI query parameter caused the error
+        let parameter: String?
+    }
+
+    public var definedFields: [String: String] {
+        let keysAndValues = [
+            id.map { ("id", String(describing: $0)) },
+            status.map { ("status", $0) },
+            code.map { ("code", $0) },
+            title.map { ("title", $0) },
+            detail.map { ("detail", $0) },
+            source.flatMap { $0.pointer.map { ("pointer", $0) } },
+            source.flatMap { $0.parameter.map { ("parameter", $0) } }
+            ].compactMap { $0 }
+        return Dictionary(uniqueKeysWithValues: keysAndValues)
+    }
+}
+
+/// `BasicJSONAPIError` optionally decodes many possible fields
+/// specified by the JSON:API 1.0 Spec. It gives no type-guarantees of what
+/// will be non-nil, but could provide good diagnostic information when
+/// you do not know what error structure to expect.
+///
+/// ```
+/// Fields:
+/// - id
+/// - status
+/// - code
+/// - title
+/// - detail
+/// - source
+///   - pointer
+///   - parameter
+/// ```
+///
+/// The JSON:API Spec does not dictate the type of this particular Id field,
+/// so you must specify whether to expect, for example, an `Int` or a `String`
+/// in the id field.
+///
+/// Something like `AnyCodable` from *Flight-School* could be
+/// a good option if you do not know what to expect. You could also use
+/// `Either<Int, String>` (provided by the `Poly` package that is
+/// already a dependency of `JSONAPI`).
+public typealias BasicJSONAPIError<IdType: Codable & Equatable> = GenericJSONAPIError<BasicJSONAPIErrorPayload<IdType>>

--- a/Sources/JSONAPI/Error/GenericJSONAPIError.swift
+++ b/Sources/JSONAPI/Error/GenericJSONAPIError.swift
@@ -1,0 +1,67 @@
+//
+//  GenericError.swift
+//  JSONAPI
+//
+//  Created by Mathew Polzin on 9/29/19.
+//
+
+import Foundation
+
+/// `GenericJSONAPIError` can be used to specify whatever error
+/// payload you expect to need to parse in responses and handle any
+/// other payload structure as `.unknownError`.
+public enum GenericJSONAPIError<ErrorPayload: Codable & Equatable>: JSONAPIError {
+    case unknownError
+    case error(ErrorPayload)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+
+        do {
+            self = .error(try container.decode(ErrorPayload.self))
+        } catch {
+            self = .unknown
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .error(let payload):
+            try container.encode(payload)
+        case .unknownError:
+            try container.encode("unknown")
+        }
+    }
+
+    public static var unknown: Self {
+        return .unknownError
+    }
+}
+
+public extension GenericJSONAPIError {
+    var payload: ErrorPayload? {
+        switch self {
+        case .unknownError:
+            return nil
+        case .error(let payload):
+            return payload
+        }
+    }
+}
+
+public protocol ErrorDictType {
+    var definedFields: [String: String] { get }
+}
+
+extension GenericJSONAPIError: ErrorDictType where ErrorPayload: ErrorDictType {
+    /// Get a dictionary of all defined fields and their values.
+    public var definedFields: [String: String] {
+        switch self {
+        case .unknownError:
+            return [:]
+        case .error(let basicPayload):
+            return basicPayload.definedFields
+        }
+    }
+}

--- a/Sources/JSONAPI/Error/GenericJSONAPIError.swift
+++ b/Sources/JSONAPI/Error/GenericJSONAPIError.swift
@@ -5,8 +5,6 @@
 //  Created by Mathew Polzin on 9/29/19.
 //
 
-import Foundation
-
 /// `GenericJSONAPIError` can be used to specify whatever error
 /// payload you expect to need to parse in responses and handle any
 /// other payload structure as `.unknownError`.

--- a/Sources/JSONAPI/Error/JSONAPIError.swift
+++ b/Sources/JSONAPI/Error/JSONAPIError.swift
@@ -11,7 +11,10 @@ public protocol JSONAPIError: Swift.Error, Equatable, Codable {
 
 /// `UnknownJSONAPIError` can actually be used in any sitaution
 /// where you don't know what errors are possible _or_ you just don't
-/// care what errors might show up.
+/// care what errors might show up. If you don't know how the error
+/// will be structured but you would like to have access to more
+/// information the server might be providing in the error payload,
+/// use `BasicJSONAPIError` instead.
 public enum UnknownJSONAPIError: JSONAPIError {
 	case unknownError
 	
@@ -24,7 +27,7 @@ public enum UnknownJSONAPIError: JSONAPIError {
 		try container.encode("unknown")
 	}
 	
-	public static var unknown: UnknownJSONAPIError {
+	public static var unknown: Self {
 		return .unknownError
 	}
 }

--- a/Tests/JSONAPITests/Error/BasicJSONAPIErrorTests.swift
+++ b/Tests/JSONAPITests/Error/BasicJSONAPIErrorTests.swift
@@ -8,6 +8,7 @@
 import Foundation
 @testable import JSONAPI
 import XCTest
+import Poly
 
 final class BasicJSONAPIErrorTests: XCTestCase {
     func test_initAndEquality() {
@@ -88,5 +89,43 @@ final class BasicJSONAPIErrorTests: XCTestCase {
         XCTAssertEqual(wellPopulatedError.definedFields["detail"], "Resource was not found")
         XCTAssertEqual(wellPopulatedError.definedFields["pointer"], "/data/attributes/id")
         XCTAssertEqual(wellPopulatedError.definedFields["parameter"], "id")
+    }
+
+    func test_decodeAFewExamples() {
+        let datas = [
+"""
+{
+    "id": "hello"
+}
+""",
+"""
+{
+    "id": 1234
+}
+""",
+"""
+{
+    "status": "404",
+    "title": "Missing",
+    "links": {
+        "about": "https://google.com"
+    }
+}
+""",
+"""
+{
+    "status": 404
+}
+"""
+        ].map { $0.data(using: .utf8)! }
+
+        let errors = datas
+            .map { decoded(type: BasicJSONAPIError<Either<Int, String>>.self, data: $0) }
+
+        XCTAssertEqual(errors[0].payload?.id, .init("hello"))
+        XCTAssertEqual(errors[1].payload?.id, .init(1234))
+        XCTAssertEqual(errors[2].payload?.status, "404")
+        XCTAssertEqual(errors[2].payload?.title, "Missing")
+        XCTAssertEqual(errors[3], .unknown)
     }
 }

--- a/Tests/JSONAPITests/Error/BasicJSONAPIErrorTests.swift
+++ b/Tests/JSONAPITests/Error/BasicJSONAPIErrorTests.swift
@@ -6,7 +6,7 @@
 //
 
 import Foundation
-@testable import JSONAPI
+import JSONAPI
 import XCTest
 import Poly
 

--- a/Tests/JSONAPITests/Error/BasicJSONAPIErrorTests.swift
+++ b/Tests/JSONAPITests/Error/BasicJSONAPIErrorTests.swift
@@ -1,0 +1,92 @@
+//
+//  BasicJSONAPIErrorTests.swift
+//  JSONAPITests
+//
+//  Created by Mathew Polzin on 9/29/19.
+//
+
+import Foundation
+@testable import JSONAPI
+import XCTest
+
+final class BasicJSONAPIErrorTests: XCTestCase {
+    func test_initAndEquality() {
+        let unknown1 = BasicJSONAPIError<String>.unknown
+        let unknown2 = BasicJSONAPIError<String>.unknownError
+        XCTAssertEqual(unknown1, unknown2)
+        let unknown3 = BasicJSONAPIError<Int>.unknownError
+        XCTAssertEqual(unknown3, .unknown)
+
+        let _ = BasicJSONAPIError<Int>.error(.init(id: nil,
+                                                   status: nil,
+                                                   code: nil,
+                                                   title: nil,
+                                                   detail: nil,
+                                                   source: nil))
+        let _ = BasicJSONAPIError<String>.error(.init(id: nil,
+                                                      status: nil,
+                                                      code: nil,
+                                                      title: nil,
+                                                      detail: nil,
+                                                      source: nil))
+
+        let intError = BasicJSONAPIError<Int>.error(.init(id: 2,
+                                                          status: nil,
+                                                          code: nil,
+                                                          title: nil,
+                                                          detail: nil,
+                                                          source: nil))
+        XCTAssertEqual(intError.payload?.id, 2)
+        XCTAssertNotEqual(intError, unknown3)
+
+        let stringError = BasicJSONAPIError<String>.error(.init(id: "hello",
+                                                                status: nil,
+                                                                code: nil,
+                                                                title: nil,
+                                                                detail: nil,
+                                                                source: nil))
+        XCTAssertEqual(stringError.payload?.id, "hello")
+        XCTAssertNotEqual(stringError, unknown1)
+
+        let wellPopulatedError = BasicJSONAPIError<Int>.error(.init(id: 10,
+                                                                    status: "404",
+                                                                    code: "12",
+                                                                    title: "Missing",
+                                                                    detail: "Resource was not found",
+                                                                    source: .init(pointer: "/data/attributes/id", parameter: "id")))
+        XCTAssertEqual(wellPopulatedError.payload?.id, 10)
+        XCTAssertEqual(wellPopulatedError.payload?.status, "404")
+        XCTAssertEqual(wellPopulatedError.payload?.code, "12")
+        XCTAssertEqual(wellPopulatedError.payload?.title, "Missing")
+        XCTAssertEqual(wellPopulatedError.payload?.detail, "Resource was not found")
+        XCTAssertEqual(wellPopulatedError.payload?.source?.pointer, "/data/attributes/id")
+        XCTAssertEqual(wellPopulatedError.payload?.source?.parameter, "id")
+
+        XCTAssertNotEqual(wellPopulatedError, intError)
+    }
+
+    func test_definedFields() {
+        let unpopulatedError = BasicJSONAPIError<Int>.error(.init(id: nil,
+                                                                  status: nil,
+                                                                  code: nil,
+                                                                  title: nil,
+                                                                  detail: nil,
+                                                                  source: nil))
+        XCTAssertEqual(unpopulatedError.definedFields.count, 0)
+
+        let wellPopulatedError = BasicJSONAPIError<Int>.error(.init(id: 10,
+                                                                    status: "404",
+                                                                    code: "12",
+                                                                    title: "Missing",
+                                                                    detail: "Resource was not found",
+                                                                    source: .init(pointer: "/data/attributes/id", parameter: "id")))
+        XCTAssertEqual(wellPopulatedError.definedFields.count, 7)
+        XCTAssertEqual(wellPopulatedError.definedFields["id"], "10")
+        XCTAssertEqual(wellPopulatedError.definedFields["status"], "404")
+        XCTAssertEqual(wellPopulatedError.definedFields["code"], "12")
+        XCTAssertEqual(wellPopulatedError.definedFields["title"], "Missing")
+        XCTAssertEqual(wellPopulatedError.definedFields["detail"], "Resource was not found")
+        XCTAssertEqual(wellPopulatedError.definedFields["pointer"], "/data/attributes/id")
+        XCTAssertEqual(wellPopulatedError.definedFields["parameter"], "id")
+    }
+}

--- a/Tests/JSONAPITests/Error/GenericJSONAPIErrorTests.swift
+++ b/Tests/JSONAPITests/Error/GenericJSONAPIErrorTests.swift
@@ -1,0 +1,139 @@
+//
+//  GenericJSONAPIErrorTests.swift
+//  JSONAPITests
+//
+//  Created by Mathew Polzin on 9/29/19.
+//
+
+import Foundation
+import JSONAPI
+import XCTest
+
+final class GenericJSONAPIErrorTests: XCTestCase {
+    func test_initAndEquality() {
+        let unknown1 = TestGenericJSONAPIError.unknown
+        let unknown2 = TestGenericJSONAPIError.unknownError
+        XCTAssertEqual(unknown1, unknown2)
+
+        let known1 = TestGenericJSONAPIError.error(.init(hello: "there", world: 3))
+        let known2 = TestGenericJSONAPIError.error(.init(hello: "there", world: nil))
+        XCTAssertNotEqual(unknown1, known1)
+        XCTAssertNotEqual(unknown1, known2)
+        XCTAssertNotEqual(known1, known2)
+    }
+
+    func test_decodeKnown() {
+        let datas = [
+"""
+{
+    "hello": "world"
+}
+""",
+"""
+{
+    "hello": "there",
+    "world": 2
+}
+""",
+"""
+{
+    "hello": "three",
+    "world": null
+}
+"""
+        ].map { $0.data(using: .utf8)! }
+
+        let errors = datas
+            .map { decoded(type: TestGenericJSONAPIError.self, data: $0) }
+
+        XCTAssertEqual(errors[0], .error(TestPayload(hello: "world", world: nil)))
+
+        XCTAssertEqual(errors[1], .error(TestPayload(hello: "there", world: 2)))
+
+        XCTAssertEqual(errors[2], .error(TestPayload(hello: "three", world: nil)))
+    }
+
+    func test_decodeUnknown() {
+        let data =
+"""
+{
+    "world": 2
+}
+""".data(using: .utf8)!
+
+        let error = decoded(type: TestGenericJSONAPIError.self, data: data)
+
+        XCTAssertEqual(error, .unknown)
+    }
+
+    func test_encode() {
+        let datas = [
+"""
+{
+    "hello": "world"
+}
+""",
+"""
+{
+    "hello": "there",
+    "world": 2
+}
+""",
+"""
+{
+    "hello": "three",
+    "world": null
+}
+"""
+        ].map { $0.data(using: .utf8)! }
+
+        datas.forEach { data in
+            test_DecodeEncodeEquality(type: TestGenericJSONAPIError.self, data: data)
+        }
+    }
+
+    func test_payloadAccess() {
+        let error1 = TestGenericJSONAPIError.error(.init(hello: "world", world: 3))
+        let error2 = TestGenericJSONAPIError.error(.init(hello: "there", world: nil))
+        let error3 = TestGenericJSONAPIError.unknown
+
+        XCTAssertEqual(error1.payload?.hello, "world")
+        XCTAssertEqual(error1.payload?.world, 3)
+        XCTAssertEqual(error2.payload?.hello, "there")
+        XCTAssertNil(error2.payload?.world)
+        XCTAssertNil(error3.payload?.hello)
+        XCTAssertNil(error3.payload?.world)
+    }
+
+    func test_definedFields() {
+        let error1 = TestGenericJSONAPIError.error(.init(hello: "world", world: 3))
+        let error2 = TestGenericJSONAPIError.error(.init(hello: "there", world: nil))
+        let error3 = TestGenericJSONAPIError.unknown
+
+        XCTAssertEqual(error1.definedFields.count, 2)
+        XCTAssertEqual(error2.definedFields.count, 1)
+        XCTAssertEqual(error3.definedFields.count, 0)
+
+        XCTAssertEqual(error1.definedFields["hello"], "world")
+        XCTAssertEqual(error1.definedFields["world"], "3")
+        XCTAssertEqual(error2.definedFields["hello"], "there")
+        XCTAssertNil(error2.definedFields["world"])
+        XCTAssertNil(error3.definedFields["hello"])
+        XCTAssertNil(error3.definedFields["world"])
+    }
+}
+
+private struct TestPayload: Codable, Equatable, ErrorDictType {
+    let hello: String
+    let world: Int?
+
+    public var definedFields: [String : String] {
+        let keysAndValues = [
+            ("hello", hello),
+            world.map { ("world", String($0)) }
+            ].compactMap { $0 }
+        return Dictionary(uniqueKeysWithValues: keysAndValues)
+    }
+}
+
+private typealias TestGenericJSONAPIError = GenericJSONAPIError<TestPayload>

--- a/Tests/JSONAPITests/Error/GenericJSONAPIErrorTests.swift
+++ b/Tests/JSONAPITests/Error/GenericJSONAPIErrorTests.swift
@@ -92,6 +92,14 @@ final class GenericJSONAPIErrorTests: XCTestCase {
         }
     }
 
+    func test_encodeUnknown() {
+        let error = TestGenericJSONAPIError.unknownError
+
+        let encodedError = encoded(value: ["errors": [error]])
+
+        XCTAssertEqual(String(data: encodedError, encoding: .utf8)!, #"{"errors":["unknown"]}"#)
+    }
+
     func test_payloadAccess() {
         let error1 = TestGenericJSONAPIError.error(.init(hello: "world", world: 3))
         let error2 = TestGenericJSONAPIError.error(.init(hello: "there", world: nil))


### PR DESCRIPTION
Addresses https://github.com/mattpolzin/JSONAPI/issues/31

This PR adds two new error-related Types. It bumps the pod spec version to 2.2.0.

The `GenericJSONAPIError` makes it easy to fit any old structure to the requirements for the `JSONAPIError` protocol.

The `BasicJSONAPIError` provides out-of-box support for parsing _most_ of the fields the JSON:API Spec says might be available on error objects. These fields are all optional because the Spec does not require any of them to be present.