### PR TITLE
Feature/primary resource body improvements

### DIFF
--- a/Sources/JSONAPI/Resource/Poly+PrimaryResource.swift
+++ b/Sources/JSONAPI/Resource/Poly+PrimaryResource.swift
@@ -18,7 +18,7 @@ import Poly
 public typealias EncodableJSONPoly = Poly & EncodablePrimaryResource
 
 public typealias EncodablePolyWrapped = Encodable & Equatable
-public typealias PolyWrapped = EncodablePolyWrapped & Decodable
+public typealias CodablePolyWrapped = EncodablePolyWrapped & Decodable
 
 extension Poly0: CodablePrimaryResource {
     public init(from decoder: Decoder) throws {
@@ -35,42 +35,42 @@ extension Poly1: EncodablePrimaryResource, OptionalEncodablePrimaryResource
     where A: EncodablePolyWrapped {}
 
 extension Poly1: CodablePrimaryResource, OptionalCodablePrimaryResource
-    where A: PolyWrapped {}
+    where A: CodablePolyWrapped {}
 
 // MARK: - 2 types
 extension Poly2: EncodablePrimaryResource, OptionalEncodablePrimaryResource
     where A: EncodablePolyWrapped, B: EncodablePolyWrapped {}
 
 extension Poly2: CodablePrimaryResource, OptionalCodablePrimaryResource
-    where A: PolyWrapped, B: PolyWrapped {}
+    where A: CodablePolyWrapped, B: CodablePolyWrapped {}
 
 // MARK: - 3 types
 extension Poly3: EncodablePrimaryResource, OptionalEncodablePrimaryResource
     where A: EncodablePolyWrapped, B: EncodablePolyWrapped, C: EncodablePolyWrapped {}
 
 extension Poly3: CodablePrimaryResource, OptionalCodablePrimaryResource
-    where A: PolyWrapped, B: PolyWrapped, C: PolyWrapped {}
+    where A: CodablePolyWrapped, B: CodablePolyWrapped, C: CodablePolyWrapped {}
 
 // MARK: - 4 types
 extension Poly4: EncodablePrimaryResource, OptionalEncodablePrimaryResource
     where A: EncodablePolyWrapped, B: EncodablePolyWrapped, C: EncodablePolyWrapped, D: EncodablePolyWrapped {}
 
 extension Poly4: CodablePrimaryResource, OptionalCodablePrimaryResource
-    where A: PolyWrapped, B: PolyWrapped, C: PolyWrapped, D: PolyWrapped {}
+    where A: CodablePolyWrapped, B: CodablePolyWrapped, C: CodablePolyWrapped, D: CodablePolyWrapped {}
 
 // MARK: - 5 types
 extension Poly5: EncodablePrimaryResource, OptionalEncodablePrimaryResource
     where A: EncodablePolyWrapped, B: EncodablePolyWrapped, C: EncodablePolyWrapped, D: EncodablePolyWrapped, E: EncodablePolyWrapped {}
 
 extension Poly5: CodablePrimaryResource, OptionalCodablePrimaryResource
-    where A: PolyWrapped, B: PolyWrapped, C: PolyWrapped, D: PolyWrapped, E: PolyWrapped {}
+    where A: CodablePolyWrapped, B: CodablePolyWrapped, C: CodablePolyWrapped, D: CodablePolyWrapped, E: CodablePolyWrapped {}
 
 // MARK: - 6 types
 extension Poly6: EncodablePrimaryResource, OptionalEncodablePrimaryResource
     where A: EncodablePolyWrapped, B: EncodablePolyWrapped, C: EncodablePolyWrapped, D: EncodablePolyWrapped, E: EncodablePolyWrapped, F: EncodablePolyWrapped {}
 
 extension Poly6: CodablePrimaryResource, OptionalCodablePrimaryResource
-    where A: PolyWrapped, B: PolyWrapped, C: PolyWrapped, D: PolyWrapped, E: PolyWrapped, F: PolyWrapped {}
+    where A: CodablePolyWrapped, B: CodablePolyWrapped, C: CodablePolyWrapped, D: CodablePolyWrapped, E: CodablePolyWrapped, F: CodablePolyWrapped {}
 
 // MARK: - 7 types
 extension Poly7: EncodablePrimaryResource, OptionalEncodablePrimaryResource
@@ -84,7 +84,7 @@ extension Poly7: EncodablePrimaryResource, OptionalEncodablePrimaryResource
         G: EncodablePolyWrapped {}
 
 extension Poly7: CodablePrimaryResource, OptionalCodablePrimaryResource
-    where A: PolyWrapped, B: PolyWrapped, C: PolyWrapped, D: PolyWrapped, E: PolyWrapped, F: PolyWrapped, G: PolyWrapped {}
+    where A: CodablePolyWrapped, B: CodablePolyWrapped, C: CodablePolyWrapped, D: CodablePolyWrapped, E: CodablePolyWrapped, F: CodablePolyWrapped, G: CodablePolyWrapped {}
 
 // MARK: - 8 types
 extension Poly8: EncodablePrimaryResource, OptionalEncodablePrimaryResource
@@ -99,7 +99,7 @@ extension Poly8: EncodablePrimaryResource, OptionalEncodablePrimaryResource
         H: EncodablePolyWrapped {}
 
 extension Poly8: CodablePrimaryResource, OptionalCodablePrimaryResource
-    where A: PolyWrapped, B: PolyWrapped, C: PolyWrapped, D: PolyWrapped, E: PolyWrapped, F: PolyWrapped, G: PolyWrapped, H: PolyWrapped {}
+    where A: CodablePolyWrapped, B: CodablePolyWrapped, C: CodablePolyWrapped, D: CodablePolyWrapped, E: CodablePolyWrapped, F: CodablePolyWrapped, G: CodablePolyWrapped, H: CodablePolyWrapped {}
 
 // MARK: - 9 types
 extension Poly9: EncodablePrimaryResource, OptionalEncodablePrimaryResource
@@ -115,7 +115,7 @@ extension Poly9: EncodablePrimaryResource, OptionalEncodablePrimaryResource
         I: EncodablePolyWrapped {}
 
 extension Poly9: CodablePrimaryResource, OptionalCodablePrimaryResource
-    where A: PolyWrapped, B: PolyWrapped, C: PolyWrapped, D: PolyWrapped, E: PolyWrapped, F: PolyWrapped, G: PolyWrapped, H: PolyWrapped, I: PolyWrapped {}
+    where A: CodablePolyWrapped, B: CodablePolyWrapped, C: CodablePolyWrapped, D: CodablePolyWrapped, E: CodablePolyWrapped, F: CodablePolyWrapped, G: CodablePolyWrapped, H: CodablePolyWrapped, I: CodablePolyWrapped {}
 
 // MARK: - 10 types
 extension Poly10: EncodablePrimaryResource, OptionalEncodablePrimaryResource
@@ -132,7 +132,7 @@ extension Poly10: EncodablePrimaryResource, OptionalEncodablePrimaryResource
         J: EncodablePolyWrapped {}
 
 extension Poly10: CodablePrimaryResource, OptionalCodablePrimaryResource
-    where A: PolyWrapped, B: PolyWrapped, C: PolyWrapped, D: PolyWrapped, E: PolyWrapped, F: PolyWrapped, G: PolyWrapped, H: PolyWrapped, I: PolyWrapped, J: PolyWrapped {}
+    where A: CodablePolyWrapped, B: CodablePolyWrapped, C: CodablePolyWrapped, D: CodablePolyWrapped, E: CodablePolyWrapped, F: CodablePolyWrapped, G: CodablePolyWrapped, H: CodablePolyWrapped, I: CodablePolyWrapped, J: CodablePolyWrapped {}
 
 // MARK: - 11 types
 extension Poly11: EncodablePrimaryResource, OptionalEncodablePrimaryResource
@@ -151,14 +151,14 @@ extension Poly11: EncodablePrimaryResource, OptionalEncodablePrimaryResource
 
 extension Poly11: CodablePrimaryResource, OptionalCodablePrimaryResource
     where
-        A: PolyWrapped,
-        B: PolyWrapped,
-        C: PolyWrapped,
-        D: PolyWrapped,
-        E: PolyWrapped,
-        F: PolyWrapped,
-        G: PolyWrapped,
-        H: PolyWrapped,
-        I: PolyWrapped,
-        J: PolyWrapped,
-        K: PolyWrapped {}
+        A: CodablePolyWrapped,
+        B: CodablePolyWrapped,
+        C: CodablePolyWrapped,
+        D: CodablePolyWrapped,
+        E: CodablePolyWrapped,
+        F: CodablePolyWrapped,
+        G: CodablePolyWrapped,
+        H: CodablePolyWrapped,
+        I: CodablePolyWrapped,
+        J: CodablePolyWrapped,
+        K: CodablePolyWrapped {}

--- a/Sources/JSONAPITesting/Comparisons/Comparison.swift
+++ b/Sources/JSONAPITesting/Comparisons/Comparison.swift
@@ -5,7 +5,13 @@
 //  Created by Mathew Polzin on 11/3/19.
 //
 
-public enum Comparison: Equatable, CustomStringConvertible {
+public protocol Comparable: CustomStringConvertible {
+    var rawValue: String { get }
+
+    var isSame: Bool { get }
+}
+
+public enum Comparison: Comparable, Equatable {
     case same
     case different(String, String)
     case prebuilt(String)
@@ -50,7 +56,7 @@ public enum Comparison: Equatable, CustomStringConvertible {
 
 public typealias NamedDifferences = [String: String]
 
-public protocol PropertyComparable: CustomStringConvertible {
+public protocol PropertyComparable: Comparable {
     var differences: NamedDifferences { get }
 }
 

--- a/Sources/JSONAPITesting/Comparisons/DocumentCompare.swift
+++ b/Sources/JSONAPITesting/Comparisons/DocumentCompare.swift
@@ -79,18 +79,6 @@ public enum BodyComparison: Equatable, CustomStringConvertible {
     public var rawValue: String { description }
 }
 
-extension EncodableJSONAPIDocument where Body: Equatable, PrimaryResourceBody: _ResourceBody {
-    public func compare(to other: Self) -> DocumentComparison {
-        return DocumentComparison(
-            apiDescription: Comparison(
-                String(describing: apiDescription),
-                String(describing: other.apiDescription)
-            ),
-            body: body.compare(to: other.body)
-        )
-    }
-}
-
 extension EncodableJSONAPIDocument where Body: Equatable, PrimaryResourceBody: _OptionalResourceBody {
     public func compare(to other: Self) -> DocumentComparison {
         return DocumentComparison(
@@ -100,36 +88,6 @@ extension EncodableJSONAPIDocument where Body: Equatable, PrimaryResourceBody: _
             ),
             body: body.compare(to: other.body)
         )
-    }
-}
-
-extension DocumentBody where Self: Equatable, PrimaryResourceBody: _ResourceBody {
-    public func compare(to other: Self) -> BodyComparison {
-
-        // rule out case where they are the same
-        guard self != other else {
-            return .same
-        }
-
-        // rule out case where they are both error bodies
-        if let errors1 = errors, let errors2 = other.errors {
-            return .differentErrors(
-                BodyComparison.compare(
-                    errors: errors1, meta, links,
-                    with: errors2, meta, links
-                )
-            )
-        }
-
-        // rule out the case where they are both data
-        if let data1 = data, let data2 = other.data {
-            return .differentData(data1.compare(to: data2))
-        }
-
-        // we are left with the case where one is data and the
-        // other is an error if self.isError, then "the error
-        // is on the left"
-        return .dataErrorMismatch(errorOnLeft: isError)
     }
 }
 

--- a/Sources/JSONAPITesting/Comparisons/DocumentDataCompare.swift
+++ b/Sources/JSONAPITesting/Comparisons/DocumentDataCompare.swift
@@ -33,8 +33,8 @@ public struct DocumentDataComparison: Equatable, PropertyComparable {
     }
 }
 
-extension DocumentBodyData {
-    public func compare<T>(to other: Self) -> DocumentDataComparison where T: ResourceObjectType, PrimaryResourceBody == SingleResourceBody<T> {
+extension DocumentBodyData where PrimaryResourceBody: _ResourceBody {
+    public func compare(to other: Self) -> DocumentDataComparison {
         return .init(
             primary: primary.compare(to: other.primary),
             includes: includes.compare(to: other.includes),
@@ -42,17 +42,10 @@ extension DocumentBodyData {
             links: Comparison(links, other.links)
         )
     }
+}
 
-    public func compare<T>(to other: Self) -> DocumentDataComparison where T: ResourceObjectType, PrimaryResourceBody == SingleResourceBody<T?> {
-        return .init(
-            primary: primary.compare(to: other.primary),
-            includes: includes.compare(to: other.includes),
-            meta: Comparison(meta, other.meta),
-            links: Comparison(links, other.links)
-        )
-    }
-
-    public func compare<T>(to other: Self) -> DocumentDataComparison where T: ResourceObjectType, PrimaryResourceBody == ManyResourceBody<T> {
+extension DocumentBodyData where PrimaryResourceBody: _OptionalResourceBody {
+    public func compare(to other: Self) -> DocumentDataComparison {
         return .init(
             primary: primary.compare(to: other.primary),
             includes: includes.compare(to: other.includes),
@@ -109,42 +102,24 @@ public struct ManyResourceObjectComparison: Equatable, PropertyComparable {
     }
 }
 
-extension SingleResourceBody where Entity: ResourceObjectType {
+extension _OptionalResourceBody where WrappedPrimaryResourceType: ResourceObjectType {
     public func compare(to other: Self) -> PrimaryResourceBodyComparison {
-        return .single(.init(value, other.value))
-    }
-}
+        guard let one = optionalResourceObject,
+            let two = other.optionalResourceObject else {
 
-public protocol _OptionalResourceObjectType {
-    associatedtype Wrapped: ResourceObjectType
+                func nilOrName<T>(_ resObj: T?) -> String {
+                    resObj.map { String(describing: type(of: $0)) } ?? "nil"
+                }
 
-    var maybeValue: Wrapped? { get }
-}
-
-extension Optional: _OptionalResourceObjectType where Wrapped: ResourceObjectType {
-    public var maybeValue: Wrapped? {
-        switch self {
-        case .none:
-            return nil
-        case .some(let value):
-            return value
-        }
-    }
-}
-
-extension SingleResourceBody where Entity: _OptionalResourceObjectType {
-    public func compare(to other: Self) -> PrimaryResourceBodyComparison {
-        guard let one = value.maybeValue,
-            let two = other.value.maybeValue else {
-                return .other(Comparison(value, other.value))
+                return .other(Comparison(nilOrName(optionalResourceObject), nilOrName(other.optionalResourceObject)))
         }
         return .single(.init(one, two))
     }
 }
 
-extension ManyResourceBody where Entity: ResourceObjectType {
+extension _ResourceBody where PrimaryResourceType: ResourceObjectType {
     public func compare(to other: Self) -> PrimaryResourceBodyComparison {
-        return .many(.init(values.compare(to: other.values, using: { r1, r2 in
+        return .many(.init(resourceObjects.compare(to: other.resourceObjects, using: { r1, r2 in
             let r1AsResource = r1 as? AbstractResourceObjectType
 
             let maybeComparison = r1AsResource
@@ -164,4 +139,46 @@ extension ManyResourceBody where Entity: ResourceObjectType {
             return comparison
         })))
     }
+}
+
+public protocol _ResourceBody {
+    associatedtype PrimaryResourceType: ResourceObjectType
+    var resourceObjects: [PrimaryResourceType] { get }
+}
+
+public protocol _OptionalResourceBody {
+    associatedtype WrappedPrimaryResourceType: ResourceObjectType
+    var optionalResourceObject: WrappedPrimaryResourceType? { get }
+}
+
+public protocol _OptionalResourceObjectType {
+    associatedtype Wrapped: ResourceObjectType
+
+    var maybeValue: Wrapped? { get }
+}
+
+extension Optional: _OptionalResourceObjectType where Wrapped: ResourceObjectType {
+    public var maybeValue: Wrapped? {
+        switch self {
+        case .none:
+            return nil
+        case .some(let value):
+            return value
+        }
+    }
+}
+
+extension ManyResourceBody: _ResourceBody where PrimaryResource: ResourceObjectType {
+    public var resourceObjects: [PrimaryResource] { values }
+}
+
+extension SingleResourceBody: _ResourceBody where PrimaryResource: ResourceObjectType {
+    public typealias PrimaryResourceType = PrimaryResource
+    public var resourceObjects: [PrimaryResource] { [value] }
+}
+
+extension SingleResourceBody: _OptionalResourceBody where PrimaryResource: _OptionalResourceObjectType {
+    public typealias WrappedPrimaryResourceType = PrimaryResource.Wrapped
+
+    public var optionalResourceObject: WrappedPrimaryResourceType? { value.maybeValue }
 }

--- a/Tests/JSONAPITestingTests/Comparisons/DocumentCompareTests.swift
+++ b/Tests/JSONAPITestingTests/Comparisons/DocumentCompareTests.swift
@@ -53,7 +53,7 @@ final class DocumentCompareTests: XCTestCase {
         ])
 
         XCTAssertEqual(d8.compare(to: d9).differences, [
-            "Body": ##"(Primary Resource: ('age' attribute: 10 ≠ 12), ('bestFriend' relationship: Optional(Id(2)) ≠ nil), ('favoriteColor' attribute: nil ≠ Optional("blue")), ('name' attribute: name ≠ Fig), (id: 1 ≠ 5))"##
+            "Body": ##"(Primary Resource: (resource 1: 'age' attribute: 10 ≠ 12, 'bestFriend' relationship: Optional(Id(2)) ≠ nil, 'favoriteColor' attribute: nil ≠ Optional("blue"), 'name' attribute: name ≠ Fig, id: 1 ≠ 5))"##
         ])
 
         XCTAssertEqual(d1.compare(to: d10).differences, [

--- a/Tests/JSONAPITestingTests/Comparisons/DocumentCompareTests.swift
+++ b/Tests/JSONAPITestingTests/Comparisons/DocumentCompareTests.swift
@@ -15,6 +15,12 @@ final class DocumentCompareTests: XCTestCase {
         XCTAssertTrue(d2.compare(to: d2).differences.isEmpty)
         XCTAssertTrue(d3.compare(to: d3).differences.isEmpty)
         XCTAssertTrue(d4.compare(to: d4).differences.isEmpty)
+        XCTAssertTrue(d5.compare(to: d5).differences.isEmpty)
+        XCTAssertTrue(d6.compare(to: d6).differences.isEmpty)
+        XCTAssertTrue(d7.compare(to: d7).differences.isEmpty)
+        XCTAssertTrue(d8.compare(to: d8).differences.isEmpty)
+        XCTAssertTrue(d9.compare(to: d9).differences.isEmpty)
+        XCTAssertTrue(d10.compare(to: d10).differences.isEmpty)
     }
 
     func test_errorAndData() {
@@ -40,6 +46,18 @@ final class DocumentCompareTests: XCTestCase {
 
         XCTAssertEqual(d3.compare(to: d6).differences, [
             "Body": ##"(Includes: (include 2: missing)), (Primary Resource: (resource 2: 'age' attribute: 10 ≠ 12, 'bestFriend' relationship: Optional(Id(2)) ≠ nil, 'favoriteColor' attribute: nil ≠ Optional("blue"), 'name' attribute: name ≠ Fig, id: 1 ≠ 5), (resource 3: missing))"##
+        ])
+
+        XCTAssertEqual(d7.compare(to: d8).differences, [
+            "Body": ##"(Primary Resource: nil ≠ ResourceObject<TestDescription, NoMetadata, NoLinks, String>)"##
+        ])
+
+        XCTAssertEqual(d8.compare(to: d9).differences, [
+            "Body": ##"(Primary Resource: ('age' attribute: 10 ≠ 12), ('bestFriend' relationship: Optional(Id(2)) ≠ nil), ('favoriteColor' attribute: nil ≠ Optional("blue")), ('name' attribute: name ≠ Fig), (id: 1 ≠ 5))"##
+        ])
+
+        XCTAssertEqual(d1.compare(to: d10).differences, [
+            "Body": ##"(Primary Resource: (resource 1: 'age' attribute: 10 ≠ 12, 'bestFriend' relationship: Optional(Id(2)) ≠ nil, 'favoriteColor' attribute: nil ≠ Optional("blue"), 'name' attribute: name ≠ Fig, id: 1 ≠ 5))"##
         ])
     }
 }
@@ -79,6 +97,8 @@ fileprivate enum TestDescription2: JSONAPI.ResourceObjectDescription {
 fileprivate typealias TestType2 = ResourceObject<TestDescription2, NoMetadata, NoLinks, String>
 
 fileprivate typealias SingleDocument = JSONAPI.Document<SingleResourceBody<TestType>, NoMetadata, NoLinks, Include2<TestType, TestType2>, NoAPIDescription, BasicJSONAPIError<String>>
+
+fileprivate typealias OptionalSingleDocument = JSONAPI.Document<SingleResourceBody<TestType?>, NoMetadata, NoLinks, Include2<TestType, TestType2>, NoAPIDescription, BasicJSONAPIError<String>>
 
 fileprivate typealias ManyDocument = JSONAPI.Document<ManyResourceBody<TestType>, NoMetadata, NoLinks, Include2<TestType, TestType2>, NoAPIDescription, BasicJSONAPIError<String>>
 
@@ -165,6 +185,38 @@ fileprivate let d6 = ManyDocument(
     apiDescription: .none,
     body: .init(resourceObjects: [r1, r1, r2]),
     includes: .init(values: [.init(r3), .init(r2)]),
+    meta: .none,
+    links: .none
+)
+
+fileprivate let d7 = OptionalSingleDocument(
+    apiDescription: .none,
+    body: .init(resourceObject: nil),
+    includes: .none,
+    meta: .none,
+    links: .none
+)
+
+fileprivate let d8 = OptionalSingleDocument(
+    apiDescription: .none,
+    body: .init(resourceObject: r1),
+    includes: .none,
+    meta: .none,
+    links: .none
+)
+
+fileprivate let d9 = OptionalSingleDocument(
+    apiDescription: .none,
+    body: .init(resourceObject: r2),
+    includes: .none,
+    meta: .none,
+    links: .none
+)
+
+fileprivate let d10 = SingleDocument(
+    apiDescription: .none,
+    body: .init(resourceObject: r2),
+    includes: .none,
     meta: .none,
     links: .none
 )


### PR DESCRIPTION
Add associated type for the primary resource on the primary resource body protocols.

Drastically reduce the footprint of document `compare(to:)` functions by using the new associated type.

Closes https://github.com/mattpolzin/JSONAPI/issues/50