### PR TITLE
Permit missing data key for optional relationships

### DIFF
--- a/Sources/JSONAPI/Resource/Relationship.swift
+++ b/Sources/JSONAPI/Resource/Relationship.swift
@@ -170,7 +170,7 @@ extension ToOneRelationship: Codable where Identifiable.Identifier: OptionalId {
         // succeeds and then attempt to coerce nil to a Identifier
         // type at which point we can store nil in `id`.
         let anyNil: Any? = nil
-        if try container.decodeNil(forKey: .data) {
+        if try !container.contains(.data) || container.decodeNil(forKey: .data) {
             guard let val = anyNil as? Identifiable.Identifier else {
                 throw DecodingError.valueNotFound(
                     Self.self,


### PR DESCRIPTION
This prevents a decoding error when `included[].relationships.*.data` is missing, using the same logic as if it was nil.