### PR TITLE
Add CompoundResource.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/mattpolzin/Poly",
         "state": {
           "branch": null,
-          "revision": "9031b8497e025cbcfae196e59eecad5ba988e267",
-          "version": "2.4.0"
+          "revision": "36ba3f624bffa34f5f9b9c7648eab3cfdcab4748",
+          "version": "2.5.0"
         }
       }
     ]

--- a/Sources/JSONAPI/Document/CompoundResource.swift
+++ b/Sources/JSONAPI/Document/CompoundResource.swift
@@ -1,0 +1,76 @@
+//
+//  CompoundResource.swift
+//  
+//
+//  Created by Mathew Polzin on 5/25/20.
+//
+
+/// A Resource Object and any relevant related resources. This object
+/// is helpful in the context of constructing a Document.
+///
+/// You can resolve a primary resource and all of the intended includes
+/// for that resource and pass them around as a `CompoundResource`
+/// prior to constructing a Document.
+///
+/// Among other things, using this abstraction means you do not need to
+/// specialized for a single or batch document at the same time as you are
+/// resolving (i.e. materializing or decoding) one or more resources and its
+/// relatives.
+public struct CompoundResource<JSONAPIModel: JSONAPI.ResourceObjectType, JSONAPIIncludeType: JSONAPI.Include>: Equatable {
+    public let primary: JSONAPIModel
+    public let relatives: [JSONAPIIncludeType]
+
+    public init(primary: JSONAPIModel, relatives: [JSONAPIIncludeType]) {
+        self.primary = primary
+        self.relatives = relatives
+    }
+}
+
+extension EncodableJSONAPIDocument where PrimaryResourceBody: EncodableResourceBody, PrimaryResourceBody.PrimaryResource: ResourceObjectType {
+    public typealias CompoundResource = JSONAPI.CompoundResource<PrimaryResourceBody.PrimaryResource, IncludeType>
+}
+
+extension SucceedableJSONAPIDocument where PrimaryResourceBody: SingleResourceBodyProtocol, PrimaryResourceBody.PrimaryResource: ResourceObjectType {
+
+    public init(
+        apiDescription: APIDescription,
+        resource: CompoundResource,
+        meta: MetaType,
+        links: LinksType
+    ) {
+        self.init(
+            apiDescription: apiDescription,
+            body: .init(resourceObject: resource.primary),
+            includes: .init(values: resource.relatives),
+            meta: meta,
+            links: links
+        )
+    }
+}
+
+extension SucceedableJSONAPIDocument where PrimaryResourceBody: ManyResourceBodyProtocol, PrimaryResourceBody.PrimaryResource: ResourceObjectType, IncludeType: Hashable {
+
+    public init(
+        apiDescription: APIDescription,
+        resources: [CompoundResource],
+        meta: MetaType,
+        links: LinksType
+    ) {
+        var included = Set<Int>()
+        let includes = resources.reduce(into: [IncludeType]()) { (result, next) in
+            for include in next.relatives {
+                if !included.contains(include.hashValue) {
+                    included.insert(include.hashValue)
+                    result.append(include)
+                }
+            }
+        }
+        self.init(
+            apiDescription: apiDescription,
+            body: .init(resourceObjects: resources.map(\.primary)),
+            includes: .init(values: Array(includes)),
+            meta: meta,
+            links: links
+        )
+    }
+}

--- a/Sources/JSONAPI/Document/ResourceBody.swift
+++ b/Sources/JSONAPI/Document/ResourceBody.swift
@@ -50,6 +50,8 @@ public func +<R: ResourceBodyAppendable>(_ left: R, right: R) -> R {
 
 public protocol SingleResourceBodyProtocol: EncodableResourceBody {
     var value: PrimaryResource { get }
+
+    init(resourceObject: PrimaryResource)
 }
 
 /// A type allowing for a document body containing 1 primary resource.
@@ -65,6 +67,8 @@ public struct SingleResourceBody<PrimaryResource: JSONAPI.OptionalEncodablePrima
 
 public protocol ManyResourceBodyProtocol: EncodableResourceBody {
     var values: [PrimaryResource] { get }
+
+    init(resourceObjects: [PrimaryResource])
 }
 
 /// A type allowing for a document body containing 0 or more primary resources.

--- a/Sources/JSONAPI/Resource/Id.swift
+++ b/Sources/JSONAPI/Resource/Id.swift
@@ -97,7 +97,14 @@ public struct Id<RawType: MaybeRawId, IdentifiableType: JSONAPI.JSONTyped>: Equa
     }
 }
 
-extension Id: Hashable, CustomStringConvertible, AbstractId, IdType where RawType: RawIdType {
+extension Id: Hashable where RawType: RawIdType {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(ObjectIdentifier(Self.self))
+        hasher.combine(rawValue)
+    }
+}
+
+extension Id: CustomStringConvertible, AbstractId, IdType where RawType: RawIdType {
     public static func id(from rawValue: RawType) -> Id<RawType, IdentifiableType> {
         return Id(rawValue: rawValue)
     }

--- a/Sources/JSONAPI/Resource/Resource Object/ResourceObject.swift
+++ b/Sources/JSONAPI/Resource/Resource Object/ResourceObject.swift
@@ -151,6 +151,18 @@ public struct ResourceObject<Description: JSONAPI.ResourceObjectDescription, Met
     }
 }
 
+// `ResourceObject` is hashable as an identifiable resource which semantically
+// means that two different resources with the same ID should yield the same
+// hash value.
+//
+// "equatability" in this context will determine if two resources have _all_ the same
+// properties, whereas hash value will determine if two resources have the same Id.
+extension ResourceObject: Hashable where EntityRawIdType: RawIdType {
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+}
+
 extension ResourceObject: Identifiable, IdentifiableResourceObjectType, Relatable where EntityRawIdType: JSONAPI.RawIdType {
     public typealias Identifier = ResourceObject.Id
 }

--- a/Tests/JSONAPITests/Document/DocumentCompoundResourceTests.swift
+++ b/Tests/JSONAPITests/Document/DocumentCompoundResourceTests.swift
@@ -1,0 +1,354 @@
+//
+//  DocumentCompoundResourceTests.swift
+//  
+//
+//  Created by Mathew Polzin on 5/25/20.
+//
+
+import Foundation
+import JSONAPITesting
+import JSONAPI
+import XCTest
+
+final class DocumentCompoundResourceTests: XCTestCase {
+    func test_singleDocumentNoIncludes() {
+        let author = DocumentTests.Author(
+            attributes: .none,
+            relationships: .none,
+            meta: .none,
+            links: .none
+        )
+
+        typealias Document = JSONAPI.Document<SingleResourceBody<DocumentTests.Author>, NoMetadata, NoLinks, NoIncludes, NoAPIDescription, UnknownJSONAPIError>
+
+        let compoundAuthor = Document.CompoundResource(primary: author, relatives: [])
+
+        let document = Document(
+            apiDescription: .none,
+            resource: compoundAuthor,
+            meta: .none,
+            links: .none
+        )
+
+        XCTAssertEqual(document.body.primaryResource?.value, author)
+        XCTAssertEqual(document.body.includes!, .none)
+    }
+
+    func test_singleDocumentEmptyIncludes() {
+        let author = DocumentTests.Author(
+            attributes: .none,
+            relationships: .none,
+            meta: .none,
+            links: .none
+        )
+
+        let book = DocumentTests.Book(
+            attributes: .init(pageCount: 10),
+            relationships: .init(
+                author: .init(resourceObject: author),
+                series: .init(ids: []),
+                collection: nil
+            ),
+            meta: .none,
+            links: .none
+        )
+
+        typealias Document = JSONAPI.Document<SingleResourceBody<DocumentTests.Book>, NoMetadata, NoLinks, Include1<DocumentTests.Author>, NoAPIDescription, UnknownJSONAPIError>
+
+        let compoundBook = Document.CompoundResource(primary: book, relatives: [])
+
+        let document = Document(
+            apiDescription: .none,
+            resource: compoundBook,
+            meta: .none,
+            links: .none
+        )
+
+        XCTAssertEqual(document.body.primaryResource?.value, book)
+        XCTAssertEqual(document.body.includes!, .none)
+    }
+
+    func test_singleDocumentWithIncludes() {
+        let author = DocumentTests.Author(
+            attributes: .none,
+            relationships: .none,
+            meta: .none,
+            links: .none
+        )
+
+        let book = DocumentTests.Book(
+            attributes: .init(pageCount: 10),
+            relationships: .init(
+                author: .init(resourceObject: author),
+                series: .init(ids: []),
+                collection: nil
+            ),
+            meta: .none,
+            links: .none
+        )
+
+        typealias Document = JSONAPI.Document<SingleResourceBody<DocumentTests.Book>, NoMetadata, NoLinks, Include1<DocumentTests.Author>, NoAPIDescription, UnknownJSONAPIError>
+
+        let compoundBook = Document.CompoundResource(
+            primary: book,
+            relatives: [.init(author)]
+        )
+
+        let document = Document(
+            apiDescription: .none,
+            resource: compoundBook,
+            meta: .none,
+            links: .none
+        )
+
+        XCTAssertEqual(document.body.primaryResource?.value, book)
+        XCTAssertEqual(document.body.includes?.values, [.init(author)])
+    }
+
+    func test_batchDocumentNoIncludes() {
+        let author = DocumentTests.Author(
+            attributes: .none,
+            relationships: .none,
+            meta: .none,
+            links: .none
+        )
+
+        let author2 = DocumentTests.Author(
+            attributes: .none,
+            relationships: .none,
+            meta: .none,
+            links: .none
+        )
+
+        typealias Document = JSONAPI.Document<ManyResourceBody<DocumentTests.Author>, NoMetadata, NoLinks, NoIncludes, NoAPIDescription, UnknownJSONAPIError>
+
+        let compoundAuthor = Document.CompoundResource(primary: author, relatives: [])
+        let compoundAuthor2 = Document.CompoundResource(primary: author2, relatives: [])
+
+        let document = Document(
+            apiDescription: .none,
+            resources: [compoundAuthor, compoundAuthor2],
+            meta: .none,
+            links: .none
+        )
+
+        XCTAssertEqual(document.body.primaryResource?.values, [author, author2])
+        XCTAssertEqual(document.body.includes!, .none)
+    }
+
+    func test_batchDocumentEmptyIncludes() {
+        let author = DocumentTests.Author(
+            attributes: .none,
+            relationships: .none,
+            meta: .none,
+            links: .none
+        )
+
+        let book = DocumentTests.Book(
+            attributes: .init(pageCount: 10),
+            relationships: .init(
+                author: .init(resourceObject: author),
+                series: .init(ids: []),
+                collection: nil
+            ),
+            meta: .none,
+            links: .none
+        )
+
+        let book2 = DocumentTests.Book(
+            attributes: .init(pageCount: 10),
+            relationships: .init(
+                author: .init(resourceObject: author),
+                series: .init(ids: []),
+                collection: nil
+            ),
+            meta: .none,
+            links: .none
+        )
+
+        typealias Document = JSONAPI.Document<ManyResourceBody<DocumentTests.Book>, NoMetadata, NoLinks, Include1<DocumentTests.Author>, NoAPIDescription, UnknownJSONAPIError>
+
+        let compoundBook = Document.CompoundResource(primary: book, relatives: [])
+        let compoundBook2 = Document.CompoundResource(primary: book2, relatives: [])
+
+        let document = Document(
+            apiDescription: .none,
+            resources: [compoundBook, compoundBook2],
+            meta: .none,
+            links: .none
+        )
+
+        XCTAssertEqual(document.body.primaryResource?.values, [book, book2])
+        XCTAssertEqual(document.body.includes!, .none)
+    }
+
+    func test_batchDocumentWithIncldues() {
+        let author = DocumentTests.Author(
+            attributes: .none,
+            relationships: .none,
+            meta: .none,
+            links: .none
+        )
+
+        let book = DocumentTests.Book(
+            attributes: .init(pageCount: 10),
+            relationships: .init(
+                author: .init(resourceObject: author),
+                series: .init(ids: []),
+                collection: nil
+            ),
+            meta: .none,
+            links: .none
+        )
+
+        let book2 = DocumentTests.Book(
+            attributes: .init(pageCount: 10),
+            relationships: .init(
+                author: .init(resourceObject: author),
+                series: .init(ids: []),
+                collection: nil
+            ),
+            meta: .none,
+            links: .none
+        )
+
+        typealias Document = JSONAPI.Document<ManyResourceBody<DocumentTests.Book>, NoMetadata, NoLinks, Include1<DocumentTests.Author>, NoAPIDescription, UnknownJSONAPIError>
+
+        let compoundBook = Document.CompoundResource(
+            primary: book,
+            relatives: [.init(author)]
+        )
+
+        let compoundBook2 = Document.CompoundResource(
+            primary: book2,
+            relatives: []
+        )
+
+        let document = Document(
+            apiDescription: .none,
+            resources: [compoundBook, compoundBook2],
+            meta: .none,
+            links: .none
+        )
+
+        XCTAssertEqual(document.body.primaryResource?.values, [book, book2])
+        XCTAssertEqual(document.body.includes?.values, [.init(author)])
+    }
+
+    func test_batchDocumentWithSameIncludeTwice() {
+        // should only add each unique include once
+
+        let author = DocumentTests.Author(
+            attributes: .none,
+            relationships: .none,
+            meta: .none,
+            links: .none
+        )
+
+        let book = DocumentTests.Book(
+            attributes: .init(pageCount: 10),
+            relationships: .init(
+                author: .init(resourceObject: author),
+                series: .init(ids: []),
+                collection: nil
+            ),
+            meta: .none,
+            links: .none
+        )
+
+        let book2 = DocumentTests.Book(
+            attributes: .init(pageCount: 10),
+            relationships: .init(
+                author: .init(resourceObject: author),
+                series: .init(ids: []),
+                collection: nil
+            ),
+            meta: .none,
+            links: .none
+        )
+
+        typealias Document = JSONAPI.Document<ManyResourceBody<DocumentTests.Book>, NoMetadata, NoLinks, Include1<DocumentTests.Author>, NoAPIDescription, UnknownJSONAPIError>
+
+        let compoundBook = Document.CompoundResource(
+            primary: book,
+            relatives: [.init(author)]
+        )
+
+        // the key in this test case is that both compound resources
+        // contain the same included relative.
+        let compoundBook2 = Document.CompoundResource(
+            primary: book2,
+            relatives: [.init(author)]
+        )
+
+        let document = Document(
+            apiDescription: .none,
+            resources: [compoundBook, compoundBook2],
+            meta: .none,
+            links: .none
+        )
+
+        XCTAssertEqual(document.body.primaryResource?.values, [book, book2])
+        XCTAssertEqual(document.body.includes?.values, [.init(author)])
+    }
+
+    func test_batchDocumentWithTwoDifferentIncludes() {
+        let author = DocumentTests.Author(
+            attributes: .none,
+            relationships: .none,
+            meta: .none,
+            links: .none
+        )
+
+        let author2 = DocumentTests.Author(
+            attributes: .none,
+            relationships: .none,
+            meta: .none,
+            links: .none
+        )
+
+        let book = DocumentTests.Book(
+            attributes: .init(pageCount: 10),
+            relationships: .init(
+                author: .init(resourceObject: author),
+                series: .init(ids: []),
+                collection: nil
+            ),
+            meta: .none,
+            links: .none
+        )
+
+        let book2 = DocumentTests.Book(
+            attributes: .init(pageCount: 10),
+            relationships: .init(
+                author: .init(resourceObject: author2),
+                series: .init(ids: []),
+                collection: nil
+            ),
+            meta: .none,
+            links: .none
+        )
+
+        typealias Document = JSONAPI.Document<ManyResourceBody<DocumentTests.Book>, NoMetadata, NoLinks, Include1<DocumentTests.Author>, NoAPIDescription, UnknownJSONAPIError>
+
+        let compoundBook = Document.CompoundResource(
+            primary: book,
+            relatives: [.init(author)]
+        )
+
+        let compoundBook2 = Document.CompoundResource(
+            primary: book2,
+            relatives: [.init(author2)]
+        )
+
+        let document = Document(
+            apiDescription: .none,
+            resources: [compoundBook, compoundBook2],
+            meta: .none,
+            links: .none
+        )
+
+        XCTAssertEqual(document.body.primaryResource?.values, [book, book2])
+        XCTAssertEqual(document.body.includes?.values, [.init(author), .init(author2)])
+    }
+}

--- a/Tests/JSONAPITests/ResourceObject/ResourceObject+HashableTests.swift
+++ b/Tests/JSONAPITests/ResourceObject/ResourceObject+HashableTests.swift
@@ -1,0 +1,119 @@
+//
+//  ResourceObject+HashableTests.swift
+//  
+//
+//  Created by Mathew Polzin on 5/26/20.
+//
+
+import XCTest
+import JSONAPI
+import JSONAPITesting
+
+class ResourceObjectHashableTests: XCTestCase {
+
+    func test_hashable_sameProeprties() {
+        let t1 = ResourceObject<ResourceObjectTests.TestEntityType5, NoMetadata, NoLinks, String>(
+            id: "hello",
+            attributes: .init(floater: 1234),
+            relationships: .none,
+            meta: .none,
+            links: .none
+        )
+
+        let t2 = ResourceObject<ResourceObjectTests.TestEntityType5, NoMetadata, NoLinks, String>(
+            id: "hello",
+            attributes: .init(floater: 1234),
+            relationships: .none,
+            meta: .none,
+            links: .none
+        )
+
+        let t3 = ResourceObject<ResourceObjectTests.TestEntityType5, NoMetadata, NoLinks, String>(
+            id: "world",
+            attributes: .init(floater: 1234),
+            relationships: .none,
+            meta: .none,
+            links: .none
+        )
+
+        XCTAssertEqual(t1, t2)
+        XCTAssertEqual(t1.hashValue, t2.hashValue)
+
+        XCTAssertEqual(t1.attributes, t3.attributes)
+        XCTAssertEqual(t1.relationships, t3.relationships)
+        XCTAssertEqual(t1.meta, t3.meta)
+        XCTAssertEqual(t1.links, t3.links)
+        XCTAssertNotEqual(t1, t3)
+        XCTAssertNotEqual(t1.hashValue, t3.hashValue)
+    }
+
+    func test_hashable_differentProeprties() {
+        let t1 = ResourceObject<ResourceObjectTests.TestEntityType5, NoMetadata, NoLinks, String>(
+            id: "hello",
+            attributes: .init(floater: 1234),
+            relationships: .none,
+            meta: .none,
+            links: .none
+        )
+
+        let t2 = ResourceObject<ResourceObjectTests.TestEntityType5, NoMetadata, NoLinks, String>(
+            id: "hello",
+            attributes: .init(floater: 11111),
+            relationships: .none,
+            meta: .none,
+            links: .none
+        )
+
+        let t3 = ResourceObject<ResourceObjectTests.TestEntityType5, NoMetadata, NoLinks, String>(
+            id: "world",
+            attributes: .init(floater: 1111),
+            relationships: .none,
+            meta: .none,
+            links: .none
+        )
+
+        XCTAssertNotEqual(t1, t2)
+        XCTAssertEqual(t1.hashValue, t2.hashValue)
+
+        XCTAssertNotEqual(t1.attributes, t3.attributes)
+        XCTAssertEqual(t1.relationships, t3.relationships)
+        XCTAssertEqual(t1.meta, t3.meta)
+        XCTAssertEqual(t1.links, t3.links)
+        XCTAssertNotEqual(t1, t3)
+        XCTAssertNotEqual(t1.hashValue, t3.hashValue)
+    }
+
+    func test_hashable_differentTypes() {
+        let t1 = ResourceObject<ResourceObjectTests.TestEntityType1, NoMetadata, NoLinks, String>(
+            id: "hello",
+            attributes: .none,
+            relationships: .none,
+            meta: .none,
+            links: .none
+        )
+
+        let t2 = ResourceObject<ResourceObjectTests.TestEntityType5, NoMetadata, NoLinks, String>(
+            id: "hello",
+            attributes: .init(floater: 1234),
+            relationships: .none,
+            meta: .none,
+            links: .none
+        )
+
+        let t3 = ResourceObject<ResourceObjectTests.TestEntityType5, NoMetadata, NoLinks, String>(
+            id: "world",
+            attributes: .init(floater: 1234),
+            relationships: .none,
+            meta: .none,
+            links: .none
+        )
+
+        XCTAssertNotEqual(t1.hashValue, t2.hashValue)
+
+        XCTAssertNotEqual(t1.hashValue, t3.hashValue)
+    }
+}
+
+extension ResourceObjectHashableTests {
+
+}


### PR DESCRIPTION
- Add `CompoundResource`
- Add `SucceedableJSONAPIDocument` and `FailableJSONAPIDocument` protocols
- Make `ResourceObject` `Hashable` when its `Id` is `Hashable`. 
- Make `Id`'s `Hashable` conformance take its type into consideration since the `Id` type's primary motivation is to retain differentiation based on the type of thing being identified.