### PR TITLE
Add id metadata to relationships.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,8 +18,11 @@ jobs:
           - swift:5.2-focal
           - swift:5.2-centos8
           - swift:5.2-amazonlinux2
-          - swiftlang/swift:nightly-5.3-xenial
-          - swiftlang/swift:nightly-5.3-bionic
+          - swift:5.3-xenial
+          - swift:5.3-bionic
+          - swift:5.3-focal
+          - swift:5.3-centos8
+          - swift:5.3-amazonlinux2
     container: ${{ matrix.image }}
     steps:
     - name: Checkout code

--- a/JSONAPI.playground/Pages/Full Client & Server Example.xcplaygroundpage/Contents.swift
+++ b/JSONAPI.playground/Pages/Full Client & Server Example.xcplaygroundpage/Contents.swift
@@ -30,8 +30,8 @@ typealias UnidentifiedJSONEntity<Description: ResourceObjectDescription> = JSONA
 // Create relationship typealiases because we do not expect
 // JSON:API Relationships for this particular API to have
 // Metadata or Links associated with them.
-typealias ToOneRelationship<Entity: JSONAPIIdentifiable> = JSONAPI.ToOneRelationship<Entity, NoMetadata, NoLinks>
-typealias ToManyRelationship<Entity: Relatable> = JSONAPI.ToManyRelationship<Entity, NoMetadata, NoLinks>
+typealias ToOneRelationship<Entity: JSONAPIIdentifiable> = JSONAPI.ToOneRelationship<Entity, NoIdMetadata, NoMetadata, NoLinks>
+typealias ToManyRelationship<Entity: Relatable> = JSONAPI.ToManyRelationship<Entity, NoIdMetadata, NoMetadata, NoLinks>
 
 // Create a typealias for a Document because we do not expect
 // JSON:API Documents for this particular API to have Metadata, Links,

--- a/JSONAPI.playground/Pages/Full Document Verbose Generation.xcplaygroundpage/Contents.swift
+++ b/JSONAPI.playground/Pages/Full Document Verbose Generation.xcplaygroundpage/Contents.swift
@@ -72,7 +72,7 @@ enum AuthorDescription: ResourceObjectDescription {
 	}
 
 	struct Relationships: JSONAPI.Relationships {
-		let articles: ToManyRelationship<Article, ToManyRelationshipMetadata, ToManyRelationshipLinks>
+		let articles: ToManyRelationship<Article, NoIdMetadata, ToManyRelationshipMetadata, ToManyRelationshipLinks>
 	}
 }
 
@@ -88,11 +88,11 @@ enum ArticleDescription: ResourceObjectDescription {
 
 	struct Relationships: JSONAPI.Relationships {
 		/// The primary attributed author of the article.
-		let primaryAuthor: ToOneRelationship<Author, NoMetadata, NoLinks>
+		let primaryAuthor: ToOneRelationship<Author, NoIdMetadata, NoMetadata, NoLinks>
 		/// All authors excluding the primary author.
 		/// It is customary to print the primary author's
 		/// name first, followed by the other authors.
-		let otherAuthors: ToManyRelationship<Author, ToManyRelationshipMetadata, ToManyRelationshipLinks>
+		let otherAuthors: ToManyRelationship<Author, NoIdMetadata, ToManyRelationshipMetadata, ToManyRelationshipLinks>
 	}
 }
 

--- a/JSONAPI.playground/Sources/Entities.swift
+++ b/JSONAPI.playground/Sources/Entities.swift
@@ -25,8 +25,8 @@ extension String: CreatableRawIdType {
 
 // MARK: - typealiases for convenience
 public typealias ExampleEntity<Description: ResourceObjectDescription> = ResourceObject<Description, NoMetadata, NoLinks, String>
-public typealias ToOne<E: JSONAPIIdentifiable> = ToOneRelationship<E, NoMetadata, NoLinks>
-public typealias ToMany<E: Relatable> = ToManyRelationship<E, NoMetadata, NoLinks>
+public typealias ToOne<E: JSONAPIIdentifiable> = ToOneRelationship<E, NoIdMetadata, NoMetadata, NoLinks>
+public typealias ToMany<E: Relatable> = ToManyRelationship<E, NoIdMetadata, NoMetadata, NoLinks>
 
 // MARK: - A few resource objects (entities)
 public enum PersonDescription: ResourceObjectDescription {

--- a/JSONAPI.podspec
+++ b/JSONAPI.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |spec|
   #
 
   spec.name         = "MP-JSONAPI"
-  spec.version      = "4.0.0"
+  spec.version      = "5.0.0"
   spec.summary      = "Swift Codable JSON API framework."
 
   # This description is used to generate tags and improve search results.

--- a/Package.resolved
+++ b/Package.resolved
@@ -3,7 +3,7 @@
     "pins": [
       {
         "package": "Poly",
-        "repositoryURL": "https://github.com/mattpolzin/Poly",
+        "repositoryURL": "https://github.com/mattpolzin/Poly.git",
         "state": {
           "branch": null,
           "revision": "36ba3f624bffa34f5f9b9c7648eab3cfdcab4748",

--- a/Sources/JSONAPI/Meta/Meta.swift
+++ b/Sources/JSONAPI/Meta/Meta.swift
@@ -28,3 +28,10 @@ public struct NoMetadata: Meta, CustomStringConvertible {
 
     public var description: String { return "No Metadata" }
 }
+
+/// The type of metadata found in a Resource Identifier Object.
+///
+/// It is sometimes more legible to differentiate between types of metadata
+/// even when the underlying type is the same. This typealias is only here
+/// to make code more easily understandable.
+public typealias NoIdMetadata = NoMetadata

--- a/Sources/JSONAPI/Resource/Relationship.swift
+++ b/Sources/JSONAPI/Resource/Relationship.swift
@@ -143,7 +143,7 @@ public struct ToManyRelationship<Relatable: JSONAPI.Relatable, IdMetaType: JSONA
     public let links: LinksType
 
     public init(idsWithMetadata ids: [(Relatable.ID, IdMetaType)], meta: MetaType, links: LinksType) {
-        self.metaIds = ids.map(ID.init)
+        self.metaIds = ids.map { ID.init($0) }
         self.meta = meta
         self.links = links
     }

--- a/Sources/JSONAPI/Resource/Relationship.swift
+++ b/Sources/JSONAPI/Resource/Relationship.swift
@@ -52,13 +52,6 @@ public struct ToOneRelationship<Identifiable: JSONAPI.JSONAPIIdentifiable, IdMet
     public let meta: MetaType
     public let links: LinksType
 
-    public init(id: Identifiable.ID, meta: MetaType, links: LinksType) where IdMetaType == NoIdMetadata {
-        self.id = id
-        self.idMeta = .none
-        self.meta = meta
-        self.links = links
-    }
-
     public init(id: (Identifiable.ID, IdMetaType), meta: MetaType, links: LinksType) {
         self.id = id.0
         self.idMeta = id.1
@@ -67,12 +60,23 @@ public struct ToOneRelationship<Identifiable: JSONAPI.JSONAPIIdentifiable, IdMet
     }
 }
 
+extension ToOneRelationship where IdMetaType == NoIdMetadata {
+    public init(id: Identifiable.ID, meta: MetaType, links: LinksType) {
+        self.id = id
+        self.idMeta = .none
+        self.meta = meta
+        self.links = links
+    }
+}
+
 extension ToOneRelationship where MetaType == NoMetadata, LinksType == NoLinks {
-    public init(id: Identifiable.ID) where IdMetaType == NoIdMetadata {
+    public init(id: (Identifiable.ID, IdMetaType)) {
         self.init(id: id, meta: .none, links: .none)
     }
+}
 
-    public init(id: (Identifiable.ID, IdMetaType)) {
+extension ToOneRelationship where IdMetaType == NoIdMetadata, MetaType == NoMetadata, LinksType == NoLinks {
+    public init(id: Identifiable.ID) {
         self.init(id: id, meta: .none, links: .none)
     }
 }
@@ -138,13 +142,6 @@ public struct ToManyRelationship<Relatable: JSONAPI.Relatable, IdMetaType: JSONA
     public let meta: MetaType
     public let links: LinksType
 
-
-    public init(ids: [Relatable.ID], meta: MetaType, links: LinksType) where IdMetaType == NoIdMetadata {
-        self.metaIds = ids.map { .init(id: $0, meta: .none) }
-        self.meta = meta
-        self.links = links
-    }
-
     public init(idsWithMetadata ids: [(Relatable.ID, IdMetaType)], meta: MetaType, links: LinksType) {
         self.metaIds = ids.map(ID.init)
         self.meta = meta
@@ -170,11 +167,15 @@ public struct ToManyRelationship<Relatable: JSONAPI.Relatable, IdMetaType: JSONA
     }
 }
 
-extension ToManyRelationship where MetaType == NoMetadata, LinksType == NoLinks {
-
-    public init(ids: [Relatable.ID]) where IdMetaType == NoIdMetadata {
-        self.init(ids: ids, meta: .none, links: .none)
+extension ToManyRelationship where IdMetaType == NoIdMetadata {
+    public init(ids: [Relatable.ID], meta: MetaType, links: LinksType) {
+        self.metaIds = ids.map { .init(id: $0, meta: .none) }
+        self.meta = meta
+        self.links = links
     }
+}
+
+extension ToManyRelationship where MetaType == NoMetadata, LinksType == NoLinks {
 
     public init(idsWithMetadata ids: [(Relatable.ID, IdMetaType)]) {
         self.init(idsWithMetadata: ids, meta: .none, links: .none)
@@ -190,6 +191,12 @@ extension ToManyRelationship where MetaType == NoMetadata, LinksType == NoLinks 
 
     public init<T: ResourceObjectType>(resourceObjects: [T]) where T.Id == Relatable.ID, IdMetaType == NoIdMetadata {
         self.init(resourceObjects: resourceObjects, meta: .none, links: .none)
+    }
+}
+
+extension ToManyRelationship where IdMetaType == NoIdMetadata, MetaType == NoMetadata, LinksType == NoLinks {
+    public init(ids: [Relatable.ID]) {
+        self.init(ids: ids, meta: .none, links: .none)
     }
 }
 

--- a/Sources/JSONAPI/Resource/Resource Object/ResourceObject.swift
+++ b/Sources/JSONAPI/Resource/Resource Object/ResourceObject.swift
@@ -203,12 +203,12 @@ public extension ResourceObject where EntityRawIdType: JSONAPI.RawIdType {
     /// A `ResourceObject.Pointer` is a `ToOneRelationship` with no metadata or links.
     /// This is just a convenient way to reference a `ResourceObject` so that
     /// other ResourceObjects' Relationships can be built up from it.
-    typealias Pointer = ToOneRelationship<ResourceObject, NoMetadata, NoLinks>
+    typealias Pointer = ToOneRelationship<ResourceObject, NoIdMetadata, NoMetadata, NoLinks>
 
     /// `ResourceObject.Pointers` is a `ToManyRelationship` with no metadata or links.
     /// This is just a convenient way to reference a bunch of ResourceObjects so
     /// that other ResourceObjects' Relationships can be built up from them.
-    typealias Pointers = ToManyRelationship<ResourceObject, NoMetadata, NoLinks>
+    typealias Pointers = ToManyRelationship<ResourceObject, NoIdMetadata, NoMetadata, NoLinks>
 
     /// Get a pointer to this resource object that can be used as a
     /// relationship to another resource object.
@@ -218,7 +218,7 @@ public extension ResourceObject where EntityRawIdType: JSONAPI.RawIdType {
 
     /// Get a pointer (i.e. `ToOneRelationship`) to this resource
     /// object with the given metadata and links attached.
-    func pointer<MType: JSONAPI.Meta, LType: JSONAPI.Links>(withMeta meta: MType, links: LType) -> ToOneRelationship<ResourceObject, MType, LType> {
+    func pointer<MType: JSONAPI.Meta, LType: JSONAPI.Links>(withMeta meta: MType, links: LType) -> ToOneRelationship<ResourceObject, NoIdMetadata, MType, LType> {
         return ToOneRelationship(resourceObject: self, meta: meta, links: links)
     }
 }
@@ -297,14 +297,14 @@ public extension ResourceObjectProxy {
     /// Access to an Id of a `ToOneRelationship`.
     /// This allows you to write `resourceObject ~> \.other` instead
     /// of `resourceObject.relationships.other.id`.
-    static func ~><OtherEntity: JSONAPIIdentifiable, MType: JSONAPI.Meta, LType: JSONAPI.Links>(entity: Self, path: KeyPath<Description.Relationships, ToOneRelationship<OtherEntity, MType, LType>>) -> OtherEntity.ID {
+    static func ~><OtherEntity: JSONAPIIdentifiable, IdMType: JSONAPI.Meta, MType: JSONAPI.Meta, LType: JSONAPI.Links>(entity: Self, path: KeyPath<Description.Relationships, ToOneRelationship<OtherEntity, IdMType, MType, LType>>) -> OtherEntity.ID {
         return entity.relationships[keyPath: path].id
     }
 
     /// Access to an Id of an optional `ToOneRelationship`.
     /// This allows you to write `resourceObject ~> \.other` instead
     /// of `resourceObject.relationships.other?.id`.
-    static func ~><OtherEntity: OptionalRelatable, MType: JSONAPI.Meta, LType: JSONAPI.Links>(entity: Self, path: KeyPath<Description.Relationships, ToOneRelationship<OtherEntity, MType, LType>?>) -> OtherEntity.ID {
+    static func ~><OtherEntity: OptionalRelatable, IdMType: JSONAPI.Meta, MType: JSONAPI.Meta, LType: JSONAPI.Links>(entity: Self, path: KeyPath<Description.Relationships, ToOneRelationship<OtherEntity, IdMType, MType, LType>?>) -> OtherEntity.ID {
         // Implementation Note: This signature applies to `ToOneRelationship<E?, _, _>?`
         // whereas the one below applies to `ToOneRelationship<E, _, _>?`
         return entity.relationships[keyPath: path]?.id
@@ -313,7 +313,7 @@ public extension ResourceObjectProxy {
     /// Access to an Id of an optional `ToOneRelationship`.
     /// This allows you to write `resourceObject ~> \.other` instead
     /// of `resourceObject.relationships.other?.id`.
-    static func ~><OtherEntity: Relatable, MType: JSONAPI.Meta, LType: JSONAPI.Links>(entity: Self, path: KeyPath<Description.Relationships, ToOneRelationship<OtherEntity, MType, LType>?>) -> OtherEntity.ID? {
+    static func ~><OtherEntity: Relatable, IdMType: JSONAPI.Meta, MType: JSONAPI.Meta, LType: JSONAPI.Links>(entity: Self, path: KeyPath<Description.Relationships, ToOneRelationship<OtherEntity, IdMType, MType, LType>?>) -> OtherEntity.ID? {
         // Implementation Note: This signature applies to `ToOneRelationship<E, _, _>?`
         // whereas the one above applies to `ToOneRelationship<E?, _, _>?`
         return entity.relationships[keyPath: path]?.id
@@ -322,14 +322,14 @@ public extension ResourceObjectProxy {
     /// Access to all Ids of a `ToManyRelationship`.
     /// This allows you to write `resourceObject ~> \.others` instead
     /// of `resourceObject.relationships.others.ids`.
-    static func ~><OtherEntity: Relatable, MType: JSONAPI.Meta, LType: JSONAPI.Links>(entity: Self, path: KeyPath<Description.Relationships, ToManyRelationship<OtherEntity, MType, LType>>) -> [OtherEntity.ID] {
+    static func ~><OtherEntity: Relatable, IdMType: JSONAPI.Meta, MType: JSONAPI.Meta, LType: JSONAPI.Links>(entity: Self, path: KeyPath<Description.Relationships, ToManyRelationship<OtherEntity, IdMType, MType, LType>>) -> [OtherEntity.ID] {
         return entity.relationships[keyPath: path].ids
     }
 
     /// Access to all Ids of an optional `ToManyRelationship`.
     /// This allows you to write `resourceObject ~> \.others` instead
     /// of `resourceObject.relationships.others?.ids`.
-    static func ~><OtherEntity: Relatable, MType: JSONAPI.Meta, LType: JSONAPI.Links>(entity: Self, path: KeyPath<Description.Relationships, ToManyRelationship<OtherEntity, MType, LType>?>) -> [OtherEntity.ID]? {
+    static func ~><OtherEntity: Relatable, IdMType: JSONAPI.Meta, MType: JSONAPI.Meta, LType: JSONAPI.Links>(entity: Self, path: KeyPath<Description.Relationships, ToManyRelationship<OtherEntity, IdMType, MType, LType>?>) -> [OtherEntity.ID]? {
         return entity.relationships[keyPath: path]?.ids
     }
 }

--- a/Sources/JSONAPITesting/Relationship+Literal.swift
+++ b/Sources/JSONAPITesting/Relationship+Literal.swift
@@ -7,14 +7,14 @@
 
 import JSONAPI
 
-extension ToOneRelationship: ExpressibleByNilLiteral where Identifiable.ID: ExpressibleByNilLiteral, MetaType == NoMetadata, LinksType == NoLinks {
+extension ToOneRelationship: ExpressibleByNilLiteral where Identifiable.ID: ExpressibleByNilLiteral, IdMetaType == NoIdMetadata, MetaType == NoMetadata, LinksType == NoLinks {
     public init(nilLiteral: ()) {
 
         self.init(id: Identifiable.ID(nilLiteral: ()))
     }
 }
 
-extension ToOneRelationship: ExpressibleByUnicodeScalarLiteral where Identifiable.ID: ExpressibleByUnicodeScalarLiteral, MetaType == NoMetadata, LinksType == NoLinks {
+extension ToOneRelationship: ExpressibleByUnicodeScalarLiteral where Identifiable.ID: ExpressibleByUnicodeScalarLiteral, IdMetaType == NoIdMetadata, MetaType == NoMetadata, LinksType == NoLinks {
     public typealias UnicodeScalarLiteralType =  Identifiable.ID.UnicodeScalarLiteralType
 
     public init(unicodeScalarLiteral value: UnicodeScalarLiteralType) {
@@ -22,7 +22,7 @@ extension ToOneRelationship: ExpressibleByUnicodeScalarLiteral where Identifiabl
     }
 }
 
-extension ToOneRelationship: ExpressibleByExtendedGraphemeClusterLiteral where Identifiable.ID: ExpressibleByExtendedGraphemeClusterLiteral, MetaType == NoMetadata, LinksType == NoLinks {
+extension ToOneRelationship: ExpressibleByExtendedGraphemeClusterLiteral where Identifiable.ID: ExpressibleByExtendedGraphemeClusterLiteral, IdMetaType == NoIdMetadata, MetaType == NoMetadata, LinksType == NoLinks {
     public typealias ExtendedGraphemeClusterLiteralType =  Identifiable.ID.ExtendedGraphemeClusterLiteralType
 
     public init(extendedGraphemeClusterLiteral value: ExtendedGraphemeClusterLiteralType) {
@@ -30,7 +30,7 @@ extension ToOneRelationship: ExpressibleByExtendedGraphemeClusterLiteral where I
     }
 }
 
-extension ToOneRelationship: ExpressibleByStringLiteral where Identifiable.ID: ExpressibleByStringLiteral, MetaType == NoMetadata, LinksType == NoLinks {
+extension ToOneRelationship: ExpressibleByStringLiteral where Identifiable.ID: ExpressibleByStringLiteral, IdMetaType == NoIdMetadata, MetaType == NoMetadata, LinksType == NoLinks {
     public typealias StringLiteralType = Identifiable.ID.StringLiteralType
 
     public init(stringLiteral value: StringLiteralType) {
@@ -38,7 +38,7 @@ extension ToOneRelationship: ExpressibleByStringLiteral where Identifiable.ID: E
     }
 }
 
-extension ToManyRelationship: ExpressibleByArrayLiteral where MetaType == NoMetadata, LinksType == NoLinks {
+extension ToManyRelationship: ExpressibleByArrayLiteral where IdMetaType == NoIdMetadata, MetaType == NoMetadata, LinksType == NoLinks {
     public typealias ArrayLiteralElement = Relatable.ID
 
     public init(arrayLiteral elements: ArrayLiteralElement...) {

--- a/Tests/JSONAPITestingTests/Comparisons/DocumentCompareTests.swift
+++ b/Tests/JSONAPITestingTests/Comparisons/DocumentCompareTests.swift
@@ -117,8 +117,8 @@ fileprivate enum TestDescription: JSONAPI.ResourceObjectDescription {
     }
 
     struct Relationships: JSONAPI.Relationships {
-        let bestFriend: ToOneRelationship<TestType2?, NoMetadata, NoLinks>
-        let parents: ToManyRelationship<TestType, NoMetadata, NoLinks>
+        let bestFriend: ToOneRelationship<TestType2?, NoIdMetadata, NoMetadata, NoLinks>
+        let parents: ToManyRelationship<TestType, NoIdMetadata, NoMetadata, NoLinks>
     }
 }
 
@@ -134,8 +134,8 @@ fileprivate enum TestDescription2: JSONAPI.ResourceObjectDescription {
     }
 
     struct Relationships: JSONAPI.Relationships {
-        let bestFriend: ToOneRelationship<TestType2?, NoMetadata, NoLinks>
-        let parents: ToManyRelationship<TestType2, NoMetadata, NoLinks>
+        let bestFriend: ToOneRelationship<TestType2?, NoIdMetadata, NoMetadata, NoLinks>
+        let parents: ToManyRelationship<TestType2, NoIdMetadata, NoMetadata, NoLinks>
     }
 }
 

--- a/Tests/JSONAPITestingTests/Comparisons/IncludesCompareTests.swift
+++ b/Tests/JSONAPITestingTests/Comparisons/IncludesCompareTests.swift
@@ -214,8 +214,8 @@ private enum TestDescription1: JSONAPI.ResourceObjectDescription {
     }
 
     struct Relationships: JSONAPI.Relationships {
-        let bestFriend: ToOneRelationship<TestType1?, NoMetadata, NoLinks>
-        let parents: ToManyRelationship<TestType1, NoMetadata, NoLinks>
+        let bestFriend: ToOneRelationship<TestType1?, NoIdMetadata, NoMetadata, NoLinks>
+        let parents: ToManyRelationship<TestType1, NoIdMetadata, NoMetadata, NoLinks>
     }
 }
 
@@ -231,8 +231,8 @@ private enum TestDescription2: JSONAPI.ResourceObjectDescription {
     }
 
     struct Relationships: JSONAPI.Relationships {
-        let bestFriend: ToOneRelationship<TestType2?, NoMetadata, NoLinks>
-        let parents: ToManyRelationship<TestType2, NoMetadata, NoLinks>
+        let bestFriend: ToOneRelationship<TestType2?, NoIdMetadata, NoMetadata, NoLinks>
+        let parents: ToManyRelationship<TestType2, NoIdMetadata, NoMetadata, NoLinks>
     }
 }
 

--- a/Tests/JSONAPITestingTests/Comparisons/RelationshipsCompareTests.swift
+++ b/Tests/JSONAPITestingTests/Comparisons/RelationshipsCompareTests.swift
@@ -163,22 +163,22 @@ final class RelationshipsCompareTests: XCTestCase {
         ])
     }
 
-    let t1 = ToOneRelationship<TestType, NoMetadata, NoLinks>(id: "123")
-    let t2 = ToOneRelationship<TestType, TestMeta, TestLinks>(id: "456", meta: .init(hello: "world"), links: .init(link: .init(url: "http://google.com")))
-    let t3 = ToManyRelationship<TestType, NoMetadata, NoLinks>(ids: ["123", "456"])
-    let t4 = ToManyRelationship<TestType, TestMeta, TestLinks>(ids: ["123", "456"], meta: .init(hello: "world"), links: .init(link: .init(url: "http://google.com")))
+    let t1 = ToOneRelationship<TestType, NoIdMetadata, NoMetadata, NoLinks>(id: "123")
+    let t2 = ToOneRelationship<TestType, NoIdMetadata, TestMeta, TestLinks>(id: "456", meta: .init(hello: "world"), links: .init(link: .init(url: "http://google.com")))
+    let t3 = ToManyRelationship<TestType, NoIdMetadata, NoMetadata, NoLinks>(ids: ["123", "456"])
+    let t4 = ToManyRelationship<TestType, NoIdMetadata, TestMeta, TestLinks>(ids: ["123", "456"], meta: .init(hello: "world"), links: .init(link: .init(url: "http://google.com")))
     let t5 = MetaRelationship<NoMetadata, TestLinks>(meta: .none, links: .init(link: .init(url: "http://google.com")))
     let t6 = MetaRelationship<TestMeta, NoLinks>(meta: .init(hello: "hi"), links: .none)
     let t7 = MetaRelationship<TestMeta, TestLinks>(meta: .init(hello: "hi"), links: .init(link: .init(url: "http://google.com")))
 
-    let t1_differentId = ToOneRelationship<TestType, NoMetadata, NoLinks>(id: "999")
-    let t3_differentId = ToManyRelationship<TestType, NoMetadata, NoLinks>(ids: ["999", "1010"])
+    let t1_differentId = ToOneRelationship<TestType, NoIdMetadata, NoMetadata, NoLinks>(id: "999")
+    let t3_differentId = ToManyRelationship<TestType, NoIdMetadata, NoMetadata, NoLinks>(ids: ["999", "1010"])
 
-    let t2_differentLinks = ToOneRelationship<TestType, TestMeta, TestLinks>(id: "456", meta: .init(hello: "world"), links: .init(link: .init(url: "http://yahoo.com")))
-    let t4_differentLinks = ToManyRelationship<TestType, TestMeta, TestLinks>(ids: ["123", "456"], meta: .init(hello: "world"), links: .init(link: .init(url: "http://yahoo.com")))
+    let t2_differentLinks = ToOneRelationship<TestType, NoIdMetadata, TestMeta, TestLinks>(id: "456", meta: .init(hello: "world"), links: .init(link: .init(url: "http://yahoo.com")))
+    let t4_differentLinks = ToManyRelationship<TestType, NoIdMetadata, TestMeta, TestLinks>(ids: ["123", "456"], meta: .init(hello: "world"), links: .init(link: .init(url: "http://yahoo.com")))
 
-    let t2_differentMeta = ToOneRelationship<TestType, TestMeta, TestLinks>(id: "456", meta: .init(hello: "there"), links: .init(link: .init(url: "http://google.com")))
-    let t4_differentMeta = ToManyRelationship<TestType, TestMeta, TestLinks>(ids: ["123", "456"], meta: .init(hello: "there"), links: .init(link: .init(url: "http://google.com")))
+    let t2_differentMeta = ToOneRelationship<TestType, NoIdMetadata, TestMeta, TestLinks>(id: "456", meta: .init(hello: "there"), links: .init(link: .init(url: "http://google.com")))
+    let t4_differentMeta = ToManyRelationship<TestType, NoIdMetadata, TestMeta, TestLinks>(ids: ["123", "456"], meta: .init(hello: "there"), links: .init(link: .init(url: "http://google.com")))
 
     let t5_differentLinks = MetaRelationship<NoMetadata, TestLinks>(meta: .none, links: .init(link: .init(url: "http://hi.com")))
     let t6_differentMeta = MetaRelationship<TestMeta, NoLinks>(meta: .init(hello: "there"), links: .none)
@@ -213,10 +213,10 @@ extension RelationshipsCompareTests {
     }
 
     struct TestRelationships: JSONAPI.Relationships {
-        let a: ToOneRelationship<TestType, NoMetadata, NoLinks>?
-        let b: ToOneRelationship<TestType, TestMeta, TestLinks>?
-        let c: ToManyRelationship<TestType, NoMetadata, NoLinks>?
-        let d: ToManyRelationship<TestType, TestMeta, TestLinks>?
+        let a: ToOneRelationship<TestType, NoIdMetadata, NoMetadata, NoLinks>?
+        let b: ToOneRelationship<TestType, NoIdMetadata, TestMeta, TestLinks>?
+        let c: ToManyRelationship<TestType, NoIdMetadata, NoMetadata, NoLinks>?
+        let d: ToManyRelationship<TestType, NoIdMetadata, TestMeta, TestLinks>?
         let e: MetaRelationship<NoMetadata, TestLinks>?
         let f: MetaRelationship<TestMeta, NoLinks>?
         let g: MetaRelationship<TestMeta, TestLinks>?

--- a/Tests/JSONAPITestingTests/Comparisons/ResourceObjectCompareTests.swift
+++ b/Tests/JSONAPITestingTests/Comparisons/ResourceObjectCompareTests.swift
@@ -146,8 +146,8 @@ private enum TestDescription: JSONAPI.ResourceObjectDescription {
     }
 
     struct Relationships: JSONAPI.Relationships {
-        let bestFriend: ToOneRelationship<TestType?, NoMetadata, NoLinks>
-        let parents: ToManyRelationship<TestType, NoMetadata, NoLinks>
+        let bestFriend: ToOneRelationship<TestType?, NoIdMetadata, NoMetadata, NoLinks>
+        let parents: ToManyRelationship<TestType, NoIdMetadata, NoMetadata, NoLinks>
     }
 }
 

--- a/Tests/JSONAPITestingTests/EntityCheckTests.swift
+++ b/Tests/JSONAPITestingTests/EntityCheckTests.swift
@@ -115,7 +115,7 @@ extension EntityCheckTests {
 		public typealias Attributes = NoAttributes
 
 		public struct Relationships: JSONAPI.Relationships {
-			let x: ToOneRelationship<OkEntity, NoMetadata, NoLinks>
+			let x: ToOneRelationship<OkEntity, NoIdMetadata, NoMetadata, NoLinks>
 			let y: Id<String, OkEntity>
 		}
 	}

--- a/Tests/JSONAPITestingTests/Relationship+LiteralTests.swift
+++ b/Tests/JSONAPITestingTests/Relationship+LiteralTests.swift
@@ -12,16 +12,16 @@ import JSONAPITesting
 class Relationship_LiteralTests: XCTestCase {
 
 	func test_NilLiteral() {
-		XCTAssertEqual(ToOneRelationship<TestEntity?, NoMetadata, NoLinks>(id: nil), nil)
+		XCTAssertEqual(ToOneRelationship<TestEntity?, NoIdMetadata, NoMetadata, NoLinks>(id: nil), nil)
 	}
 
 	func test_ArrayLiteral() {
-		XCTAssertEqual(ToManyRelationship<TestEntity, NoMetadata, NoLinks>(ids: ["1", "2", "3"]), ["1", "2", "3"])
+		XCTAssertEqual(ToManyRelationship<TestEntity, NoIdMetadata, NoMetadata, NoLinks>(ids: ["1", "2", "3"]), ["1", "2", "3"])
 	}
 
 	func test_StringLiteral() {
-		XCTAssertEqual(ToOneRelationship<TestEntity, NoMetadata, NoLinks>(id: "123"), "123")
-		XCTAssertEqual(ToOneRelationship<TestEntity?, NoMetadata, NoLinks>(id: "123"), "123")
+		XCTAssertEqual(ToOneRelationship<TestEntity, NoIdMetadata, NoMetadata, NoLinks>(id: "123"), "123")
+		XCTAssertEqual(ToOneRelationship<TestEntity?, NoIdMetadata, NoMetadata, NoLinks>(id: "123"), "123")
 	}
 }
 

--- a/Tests/JSONAPITests/Computed Properties/ComputedPropertiesTests.swift
+++ b/Tests/JSONAPITests/Computed Properties/ComputedPropertiesTests.swift
@@ -66,9 +66,9 @@ extension ComputedPropertiesTests {
 		}
 
 		public struct Relationships: JSONAPI.Relationships {
-			public let other: ToOneRelationship<TestType, NoMetadata, NoLinks>
+			public let other: ToOneRelationship<TestType, NoIdMetadata, NoMetadata, NoLinks>
 
-			public var computed: ToOneRelationship<TestType, NoMetadata, NoLinks> {
+			public var computed: ToOneRelationship<TestType, NoIdMetadata, NoMetadata, NoLinks> {
 				return other
 			}
 		}

--- a/Tests/JSONAPITests/Document/DocumentDecodingErrorTests.swift
+++ b/Tests/JSONAPITests/Document/DocumentDecodingErrorTests.swift
@@ -161,7 +161,7 @@ extension DocumentDecodingErrorTests {
         typealias Attributes = NoAttributes
 
         struct Relationships: JSONAPI.Relationships {
-            let author: ToOneRelationship<Author, NoMetadata, NoLinks>
+            let author: ToOneRelationship<Author, NoIdMetadata, NoMetadata, NoLinks>
         }
     }
 
@@ -179,8 +179,8 @@ extension DocumentDecodingErrorTests {
         }
 
         struct Relationships: JSONAPI.Relationships {
-            let author: ToOneRelationship<Author, NoMetadata, NoLinks>
-            let series: ToManyRelationship<Book, NoMetadata, NoLinks>
+            let author: ToOneRelationship<Author, NoIdMetadata, NoMetadata, NoLinks>
+            let series: ToManyRelationship<Book, NoIdMetadata, NoMetadata, NoLinks>
         }
     }
 

--- a/Tests/JSONAPITests/Document/DocumentTests.swift
+++ b/Tests/JSONAPITests/Document/DocumentTests.swift
@@ -1575,7 +1575,7 @@ extension DocumentTests {
 		typealias Attributes = NoAttributes
 		
 		struct Relationships: JSONAPI.Relationships {
-			let author: ToOneRelationship<Author, NoMetadata, NoLinks>
+			let author: ToOneRelationship<Author, NoIdMetadata, NoMetadata, NoLinks>
 		}
 	}
 	
@@ -1593,8 +1593,8 @@ extension DocumentTests {
         }
 
         struct Relationships: JSONAPI.Relationships {
-            let author: ToOneRelationship<Author, NoMetadata, NoLinks>
-            let series: ToManyRelationship<Book, NoMetadata, NoLinks>
+            let author: ToOneRelationship<Author, NoIdMetadata, NoMetadata, NoLinks>
+            let series: ToManyRelationship<Book, NoIdMetadata, NoMetadata, NoLinks>
             let collection: MetaRelationship<NoMetadata, TestLinks>?
         }
     }

--- a/Tests/JSONAPITests/Includes/IncludeTests.swift
+++ b/Tests/JSONAPITests/Includes/IncludeTests.swift
@@ -417,7 +417,7 @@ extension IncludedTests {
         public static var jsonType: String { return "test_entity2" }
 
         public struct Relationships: JSONAPI.Relationships {
-            let entity1: ToOneRelationship<TestEntity, NoMetadata, NoLinks>
+            let entity1: ToOneRelationship<TestEntity, NoIdMetadata, NoMetadata, NoLinks>
         }
 
         public struct Attributes: JSONAPI.SparsableAttributes {
@@ -440,8 +440,8 @@ extension IncludedTests {
 		public static var jsonType: String { return "test_entity3" }
 		
 		public struct Relationships: JSONAPI.Relationships {
-			let entity1: ToOneRelationship<TestEntity, NoMetadata, NoLinks>
-			let entity2: ToManyRelationship<TestEntity2, NoMetadata, NoLinks>
+			let entity1: ToOneRelationship<TestEntity, NoIdMetadata, NoMetadata, NoLinks>
+			let entity2: ToManyRelationship<TestEntity2, NoIdMetadata, NoMetadata, NoLinks>
 		}
 	}
 
@@ -476,7 +476,7 @@ extension IncludedTests {
 		public static var jsonType: String { return "test_entity6" }
 
 		struct Relationships: JSONAPI.Relationships {
-			let entity4: ToOneRelationship<TestEntity4, NoMetadata, NoLinks>
+			let entity4: ToOneRelationship<TestEntity4, NoIdMetadata, NoMetadata, NoLinks>
 		}
 	}
 

--- a/Tests/JSONAPITests/Includes/IncludesDecodingErrorTests.swift
+++ b/Tests/JSONAPITests/Includes/IncludesDecodingErrorTests.swift
@@ -67,7 +67,7 @@ extension IncludesDecodingErrorTests {
         public static var jsonType: String { return "test_entity2" }
 
         public struct Relationships: JSONAPI.Relationships {
-            let entity1: ToOneRelationship<TestEntity, NoMetadata, NoLinks>
+            let entity1: ToOneRelationship<TestEntity, NoIdMetadata, NoMetadata, NoLinks>
         }
 
         public struct Attributes: JSONAPI.SparsableAttributes {
@@ -101,7 +101,7 @@ extension IncludesDecodingErrorTests {
         public static var jsonType: String { return "test_entity6" }
 
         struct Relationships: JSONAPI.Relationships {
-            let entity4: ToOneRelationship<TestEntity4, NoMetadata, NoLinks>
+            let entity4: ToOneRelationship<TestEntity4, NoIdMetadata, NoMetadata, NoLinks>
         }
     }
 

--- a/Tests/JSONAPITests/NonJSONAPIRelatable/NonJSONAPIRelatableTests.swift
+++ b/Tests/JSONAPITests/NonJSONAPIRelatable/NonJSONAPIRelatableTests.swift
@@ -58,8 +58,8 @@ extension NonJSONAPIRelatableTests {
 		typealias Attributes = NoAttributes
 
 		struct Relationships: JSONAPI.Relationships {
-			let one: ToOneRelationship<NonJSONAPIEntity, NoMetadata, NoLinks>
-			let many: ToManyRelationship<NonJSONAPIEntity, NoMetadata, NoLinks>
+			let one: ToOneRelationship<NonJSONAPIEntity, NoIdMetadata, NoMetadata, NoLinks>
+			let many: ToManyRelationship<NonJSONAPIEntity, NoIdMetadata, NoMetadata, NoLinks>
 		}
 	}
 
@@ -71,10 +71,10 @@ extension NonJSONAPIRelatableTests {
 		typealias Attributes = NoAttributes
 
 		struct Relationships: JSONAPI.Relationships {
-			let nullableOne: ToOneRelationship<NonJSONAPIEntity?, NoMetadata, NoLinks>
-			let nullableMaybeOne: ToOneRelationship<NonJSONAPIEntity?, NoMetadata, NoLinks>?
-			let maybeOne: ToOneRelationship<NonJSONAPIEntity, NoMetadata, NoLinks>?
-			let maybeMany: ToManyRelationship<NonJSONAPIEntity, NoMetadata, NoLinks>?
+			let nullableOne: ToOneRelationship<NonJSONAPIEntity?, NoIdMetadata, NoMetadata, NoLinks>
+			let nullableMaybeOne: ToOneRelationship<NonJSONAPIEntity?, NoIdMetadata, NoMetadata, NoLinks>?
+			let maybeOne: ToOneRelationship<NonJSONAPIEntity, NoIdMetadata, NoMetadata, NoLinks>?
+			let maybeMany: ToManyRelationship<NonJSONAPIEntity, NoIdMetadata, NoMetadata, NoLinks>?
 		}
 	}
 

--- a/Tests/JSONAPITests/Relationships/RelationshipTests.swift
+++ b/Tests/JSONAPITests/Relationships/RelationshipTests.swift
@@ -15,7 +15,7 @@ class RelationshipTests: XCTestCase {
 		let entity2 = TestEntity1(attributes: .none, relationships: .none, meta: .none, links: .none)
 		let entity3 = TestEntity1(attributes: .none, relationships: .none, meta: .none, links: .none)
 		let entity4 = TestEntity1(attributes: .none, relationships: .none, meta: .none, links: .none)
-		let relationship = ToManyRelationship<TestEntity1, NoMetadata, NoLinks>(resourceObjects: [entity1, entity2, entity3, entity4])
+		let relationship = ToManyRelationship<TestEntity1, NoIdMetadata, NoMetadata, NoLinks>(resourceObjects: [entity1, entity2, entity3, entity4])
 
 		XCTAssertEqual(relationship.ids.count, 4)
 		XCTAssertEqual(relationship.ids, [entity1, entity2, entity3, entity4].map(\.id))
@@ -26,7 +26,7 @@ class RelationshipTests: XCTestCase {
 		let entity2 = TestEntity1(attributes: .none, relationships: .none, meta: .none, links: .none)
 		let entity3 = TestEntity1(attributes: .none, relationships: .none, meta: .none, links: .none)
 		let entity4 = TestEntity1(attributes: .none, relationships: .none, meta: .none, links: .none)
-		let relationship = ToManyRelationship<TestEntity1, NoMetadata, NoLinks>(pointers: [entity1.pointer, entity2.pointer, entity3.pointer, entity4.pointer])
+		let relationship = ToManyRelationship<TestEntity1, NoIdMetadata, NoMetadata, NoLinks>(pointers: [entity1.pointer, entity2.pointer, entity3.pointer, entity4.pointer])
 
 		XCTAssertEqual(relationship.ids.count, 4)
 		XCTAssertEqual(relationship.ids, [entity1, entity2, entity3, entity4].map(\.id))
@@ -87,14 +87,14 @@ extension RelationshipTests {
     }
 
 	func test_ToOneRelationship() {
-		let relationship = decoded(type: ToOneRelationship<TestEntity1, NoMetadata, NoLinks>.self,
+		let relationship = decoded(type: ToOneRelationship<TestEntity1, NoIdMetadata, NoMetadata, NoLinks>.self,
 								   data: to_one_relationship)
 
 		XCTAssertEqual(relationship.id.rawValue, "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF")
 	}
 
 	func test_ToOneRelationship_encode() {
-		test_DecodeEncodeEquality(type: ToOneRelationship<TestEntity1, NoMetadata, NoLinks>.self,
+		test_DecodeEncodeEquality(type: ToOneRelationship<TestEntity1, NoIdMetadata, NoMetadata, NoLinks>.self,
 								   data: to_one_relationship)
 	}
 
@@ -110,6 +110,19 @@ extension RelationshipTests {
 		test_DecodeEncodeEquality(type: ToOneWithMeta.self,
 								  data: to_one_relationship_with_meta)
 	}
+
+    func test_ToOneRelationshipWithMetaInsideIdentifier() {
+        let relationship = decoded(type: ToOneWithMetaInIds.self,
+                                   data: to_one_relationship_with_meta_inside_identifier)
+
+        XCTAssertEqual(relationship.id.rawValue, "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF")
+        XCTAssertEqual(relationship.idMeta.a, "hello")
+    }
+
+    func test_ToOneRelationshipWithMetaInsideIdentifier_encode() {
+        test_DecodeEncodeEquality(type: ToOneWithMetaInIds.self,
+                                  data: to_one_relationship_with_meta_inside_identifier)
+    }
 
 	func test_ToOneRelationshipWithLinks() {
 		let relationship = decoded(type: ToOneWithLinks.self,
@@ -139,14 +152,14 @@ extension RelationshipTests {
 	}
 
 	func test_ToManyRelationship() {
-		let relationship = decoded(type: ToManyRelationship<TestEntity1, NoMetadata, NoLinks>.self,
+		let relationship = decoded(type: ToManyRelationship<TestEntity1, NoIdMetadata, NoMetadata, NoLinks>.self,
 								   data: to_many_relationship)
 
 		XCTAssertEqual(relationship.ids.map(\.rawValue), ["2DF03B69-4B0A-467F-B52E-B0C9E44FCECF", "90F03B69-4DF1-467F-B52E-B0C9E44FC333", "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF"])
 	}
 
 	func test_ToManyRelationship_encode() {
-		test_DecodeEncodeEquality(type: ToManyRelationship<TestEntity1, NoMetadata, NoLinks>.self,
+		test_DecodeEncodeEquality(type: ToManyRelationship<TestEntity1, NoIdMetadata, NoMetadata, NoLinks>.self,
 								   data: to_many_relationship)
 	}
 
@@ -162,6 +175,19 @@ extension RelationshipTests {
 		test_DecodeEncodeEquality(type: ToManyWithMeta.self,
 								  data: to_many_relationship_with_meta)
 	}
+
+    func test_ToManyRelationshipWithMetaInsideIdentifier() {
+        let relationship = decoded(type: ToManyWithMetaInIds.self,
+                                   data: to_many_relationship_with_meta_inside_identifier)
+
+        XCTAssertEqual(relationship.ids.map(\.rawValue), ["2DF03B69-4B0A-467F-B52E-B0C9E44FCECF", "90F03B69-4DF1-467F-B52E-B0C9E44FC333", "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF"])
+        XCTAssertEqual(relationship.metaIds[0].meta.a, "hello")
+    }
+
+    func test_ToManyRelationshipWithMetaInsideIdentifier_encode() {
+        test_DecodeEncodeEquality(type: ToManyWithMetaInIds.self,
+                                  data: to_many_relationship_with_meta_inside_identifier)
+    }
 
 	func test_ToManyRelationshipWithLinks() {
 		let relationship = decoded(type: ToManyWithLinks.self,
@@ -213,11 +239,11 @@ extension RelationshipTests {
 // MARK: Failure tests
 extension RelationshipTests {
 	func test_ToManyTypeMismatch() {
-		XCTAssertThrowsError(try JSONDecoder().decode(ToManyRelationship<TestEntity1, NoMetadata, NoLinks>.self, from: to_many_relationship_type_mismatch))
+		XCTAssertThrowsError(try JSONDecoder().decode(ToManyRelationship<TestEntity1, NoIdMetadata, NoMetadata, NoLinks>.self, from: to_many_relationship_type_mismatch))
 	}
 
 	func test_ToOneTypeMismatch() {
-		XCTAssertThrowsError(try JSONDecoder().decode(ToOneRelationship<TestEntity1, NoMetadata, NoLinks>.self, from: to_one_relationship_type_mismatch))
+		XCTAssertThrowsError(try JSONDecoder().decode(ToOneRelationship<TestEntity1, NoIdMetadata, NoMetadata, NoLinks>.self, from: to_one_relationship_type_mismatch))
 	}
 }
 
@@ -233,17 +259,22 @@ extension RelationshipTests {
 
 	typealias TestEntity1 = BasicEntity<TestEntityType1>
 
-	typealias ToOneWithMeta = ToOneRelationship<TestEntity1, TestMeta, NoLinks>
+	typealias ToOneWithMeta = ToOneRelationship<TestEntity1, NoIdMetadata, TestMeta, NoLinks>
+    typealias ToOneWithMetaInIds = ToOneRelationship<TestEntity1, TestMeta, NoMetadata, NoLinks>
 
-	typealias ToOneWithLinks = ToOneRelationship<TestEntity1, NoMetadata, TestLinks>
-	typealias ToOneWithMetaAndLinks = ToOneRelationship<TestEntity1, TestMeta, TestLinks>
+	typealias ToOneWithLinks = ToOneRelationship<TestEntity1, NoIdMetadata, NoMetadata, TestLinks>
 
-	typealias ToManyWithMeta = ToManyRelationship<TestEntity1, TestMeta, NoLinks>
-	typealias ToManyWithLinks = ToManyRelationship<TestEntity1, NoMetadata, TestLinks>
-	typealias ToManyWithMetaAndLinks = ToManyRelationship<TestEntity1, TestMeta, TestLinks>
+    typealias ToOneWithMetaAndLinks = ToOneRelationship<TestEntity1, NoIdMetadata, TestMeta, TestLinks>
 
-	typealias ToOneNullable = ToOneRelationship<TestEntity1?, NoMetadata, NoLinks>
-	typealias ToOneNonNullable = ToOneRelationship<TestEntity1, NoMetadata, NoLinks>
+	typealias ToManyWithMeta = ToManyRelationship<TestEntity1, NoIdMetadata, TestMeta, NoLinks>
+    typealias ToManyWithMetaInIds = ToManyRelationship<TestEntity1, TestMeta, NoMetadata, NoLinks>
+
+    typealias ToManyWithLinks = ToManyRelationship<TestEntity1, NoIdMetadata, NoMetadata, TestLinks>
+
+    typealias ToManyWithMetaAndLinks = ToManyRelationship<TestEntity1, NoIdMetadata, TestMeta, TestLinks>
+
+	typealias ToOneNullable = ToOneRelationship<TestEntity1?, NoIdMetadata, NoMetadata, NoLinks>
+	typealias ToOneNonNullable = ToOneRelationship<TestEntity1, NoIdMetadata, NoMetadata, NoLinks>
 
 	struct TestMeta: JSONAPI.Meta {
 		let a: String

--- a/Tests/JSONAPITests/Relationships/RelationshipTests.swift
+++ b/Tests/JSONAPITests/Relationships/RelationshipTests.swift
@@ -31,6 +31,26 @@ class RelationshipTests: XCTestCase {
 		XCTAssertEqual(relationship.ids.count, 4)
 		XCTAssertEqual(relationship.ids, [entity1, entity2, entity3, entity4].map(\.id))
 	}
+
+    func test_initToOneWithIdMeta() {
+        let entity1 = TestEntity1(attributes: .none, relationships: .none, meta: .none, links: .none)
+        let relationship = ToOneWithMetaInIds(
+            id: (entity1.id, .init(a: "hello"))
+        )
+        XCTAssertEqual(relationship.id, entity1.id)
+        XCTAssertEqual(relationship.idMeta, .init(a: "hello"))
+    }
+
+    func test_initToManyWithIdMeta() {
+        let entity1 = TestEntity1(attributes: .none, relationships: .none, meta: .none, links: .none)
+        let relationship = ToManyWithMetaInIds(
+            idsWithMetadata: [
+                (entity1.id, .init(a: "hello"))
+            ]
+        )
+        XCTAssertEqual(relationship.ids, [entity1.id])
+        XCTAssertEqual(relationship.idsWithMeta, [.init(id: entity1.id, meta: .init(a: "hello"))])
+    }
 }
 
 // MARK: - Encode/Decode
@@ -181,7 +201,7 @@ extension RelationshipTests {
                                    data: to_many_relationship_with_meta_inside_identifier)
 
         XCTAssertEqual(relationship.ids.map(\.rawValue), ["2DF03B69-4B0A-467F-B52E-B0C9E44FCECF", "90F03B69-4DF1-467F-B52E-B0C9E44FC333", "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF"])
-        XCTAssertEqual(relationship.metaIds[0].meta.a, "hello")
+        XCTAssertEqual(relationship.idsWithMeta[0].meta.a, "hello")
     }
 
     func test_ToManyRelationshipWithMetaInsideIdentifier_encode() {
@@ -234,6 +254,10 @@ extension RelationshipTests {
 
 		XCTAssertEqual(encoded(value: relationship1), encoded(value: relationship2))
 	}
+
+    func test_nullableIdMeta() {
+        let _ = decoded(type: ToOneRelationship<TestEntity1?, TestMeta?, NoMetadata, NoLinks>.self, data: to_one_relationship_nulled_out)
+    }
 }
 
 // MARK: Failure tests
@@ -245,6 +269,10 @@ extension RelationshipTests {
 	func test_ToOneTypeMismatch() {
 		XCTAssertThrowsError(try JSONDecoder().decode(ToOneRelationship<TestEntity1, NoIdMetadata, NoMetadata, NoLinks>.self, from: to_one_relationship_type_mismatch))
 	}
+
+    func test_toOneNulledOutWithExpectedIdMetadata() {
+        XCTAssertThrowsError(try JSONDecoder().decode(ToOneRelationship<TestEntity1?, TestMeta, NoMetadata, NoLinks>.self, from: to_one_relationship_nulled_out))
+    }
 }
 
 // MARK: - Test types

--- a/Tests/JSONAPITests/Relationships/stubs/RelationshipStubs.swift
+++ b/Tests/JSONAPITests/Relationships/stubs/RelationshipStubs.swift
@@ -41,6 +41,12 @@ let to_one_relationship = """
 }
 """.data(using: .utf8)!
 
+let to_one_relationship_nulled_out = """
+{
+    "data": null
+}
+""".data(using: .utf8)!
+
 let to_one_relationship_type_mismatch = """
 {
 	"data": {

--- a/Tests/JSONAPITests/Relationships/stubs/RelationshipStubs.swift
+++ b/Tests/JSONAPITests/Relationships/stubs/RelationshipStubs.swift
@@ -62,6 +62,18 @@ let to_one_relationship_with_meta = """
 }
 """.data(using: .utf8)!
 
+let to_one_relationship_with_meta_inside_identifier = """
+{
+    "data": {
+        "type": "test_entity1",
+        "id": "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF",
+        "meta": {
+                "a": "hello"
+        }
+    }
+}
+""".data(using: .utf8)!
+
 let to_one_relationship_with_links = """
 {
 	"data": {
@@ -127,6 +139,34 @@ let to_many_relationship_with_meta = """
 	"meta": {
 		"a": "hello"
 	}
+}
+""".data(using: .utf8)!
+
+let to_many_relationship_with_meta_inside_identifier = """
+{
+    "data": [
+        {
+            "type": "test_entity1",
+            "id": "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF",
+            "meta": {
+                "a": "hello"
+            }
+        },
+        {
+            "type": "test_entity1",
+            "id": "90F03B69-4DF1-467F-B52E-B0C9E44FC333",
+            "meta": {
+                "a": "hello"
+            }
+        },
+        {
+            "type": "test_entity1",
+            "id": "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF",
+            "meta": {
+                "a": "hello"
+            }
+        }
+    ]
 }
 """.data(using: .utf8)!
 

--- a/Tests/JSONAPITests/ResourceObject/ResourceObject+ReplacingTests.swift
+++ b/Tests/JSONAPITests/ResourceObject/ResourceObject+ReplacingTests.swift
@@ -134,7 +134,7 @@ private enum MutableTestDescription: JSONAPI.ResourceObjectDescription {
     }
 
     struct Relationships: JSONAPI.Relationships {
-        var other: ToOneRelationship<MutableTestType, NoMetadata, NoLinks>
+        var other: ToOneRelationship<MutableTestType, NoIdMetadata, NoMetadata, NoLinks>
     }
 }
 
@@ -148,7 +148,7 @@ private enum ImmutableTestDescription: JSONAPI.ResourceObjectDescription {
     }
 
     struct Relationships: JSONAPI.Relationships {
-        let other: ToOneRelationship<ImmutableTestType, NoMetadata, NoLinks>
+        let other: ToOneRelationship<ImmutableTestType, NoIdMetadata, NoMetadata, NoLinks>
     }
 }
 

--- a/Tests/JSONAPITests/ResourceObject/ResourceObjectDecodingErrorTests.swift
+++ b/Tests/JSONAPITests/ResourceObject/ResourceObjectDecodingErrorTests.swift
@@ -457,8 +457,8 @@ extension ResourceObjectDecodingErrorTests {
 
         public struct Relationships: JSONAPI.Relationships {
 
-            let required: ToOneRelationship<TestEntity, NoMetadata, NoLinks>
-            let omittable: ToManyRelationship<TestEntity, NoMetadata, NoLinks>?
+            let required: ToOneRelationship<TestEntity, NoIdMetadata, NoMetadata, NoLinks>
+            let omittable: ToManyRelationship<TestEntity, NoIdMetadata, NoMetadata, NoLinks>?
         }
     }
 

--- a/Tests/JSONAPITests/ResourceObject/ResourceObjectTests.swift
+++ b/Tests/JSONAPITests/ResourceObject/ResourceObjectTests.swift
@@ -687,7 +687,7 @@ extension ResourceObjectTests {
 		typealias Attributes = NoAttributes
 
 		struct Relationships: JSONAPI.Relationships {
-			let other: ToOneRelationship<TestEntity1, NoMetadata, NoLinks>
+			let other: ToOneRelationship<TestEntity1, NoIdMetadata, NoMetadata, NoLinks>
 		}
 	}
 
@@ -699,7 +699,7 @@ extension ResourceObjectTests {
 		typealias Attributes = NoAttributes
 
 		struct Relationships: JSONAPI.Relationships {
-			let others: ToManyRelationship<TestEntity1, NoMetadata, NoLinks>
+			let others: ToManyRelationship<TestEntity1, NoIdMetadata, NoMetadata, NoLinks>
 		}
 	}
 
@@ -709,7 +709,7 @@ extension ResourceObjectTests {
 		static var jsonType: String { return "fourth_test_entities"}
 
 		struct Relationships: JSONAPI.Relationships {
-			let other: ToOneRelationship<TestEntity2, NoMetadata, NoLinks>
+			let other: ToOneRelationship<TestEntity2, NoIdMetadata, NoMetadata, NoLinks>
 		}
 
 		struct Attributes: JSONAPI.Attributes {
@@ -794,15 +794,15 @@ extension ResourceObjectTests {
 
             let optionalMeta: MetaRelationship<TestEntityMeta, NoLinks>?
 
-			let one: ToOneRelationship<TestEntity1, NoMetadata, NoLinks>
+			let one: ToOneRelationship<TestEntity1, NoIdMetadata, NoMetadata, NoLinks>
 
-			let nullableOne: ToOneRelationship<TestEntity1?, NoMetadata, NoLinks>
+			let nullableOne: ToOneRelationship<TestEntity1?, NoIdMetadata, NoMetadata, NoLinks>
 
-			let optionalOne: ToOneRelationship<TestEntity1, NoMetadata, NoLinks>?
+			let optionalOne: ToOneRelationship<TestEntity1, NoIdMetadata, NoMetadata, NoLinks>?
 
-			let optionalNullableOne: ToOneRelationship<TestEntity1?, NoMetadata, NoLinks>?
+			let optionalNullableOne: ToOneRelationship<TestEntity1?, NoIdMetadata, NoMetadata, NoLinks>?
 
-			let optionalMany: ToManyRelationship<TestEntity1, NoMetadata, NoLinks>?
+			let optionalMany: ToManyRelationship<TestEntity1, NoIdMetadata, NoMetadata, NoLinks>?
 
 			// a nullable many is not allowed. it should
 			// just be an empty array.
@@ -817,8 +817,8 @@ extension ResourceObjectTests {
 		typealias Attributes = NoAttributes
 
 		public struct Relationships: JSONAPI.Relationships {
-			let selfRef: ToOneRelationship<TestEntity10, NoMetadata, NoLinks>
-			let selfRefs: ToManyRelationship<TestEntity10, NoMetadata, NoLinks>
+			let selfRef: ToOneRelationship<TestEntity10, NoIdMetadata, NoMetadata, NoLinks>
+			let selfRefs: ToManyRelationship<TestEntity10, NoIdMetadata, NoMetadata, NoLinks>
 		}
 	}
 
@@ -851,11 +851,11 @@ extension ResourceObjectTests {
 
             let optionalMeta: MetaRelationship<TestEntityMeta, NoLinks>?
 
-			let optionalOne: ToOneRelationship<TestEntity1, NoMetadata, NoLinks>?
+			let optionalOne: ToOneRelationship<TestEntity1, NoIdMetadata, NoMetadata, NoLinks>?
 
-			let optionalNullableOne: ToOneRelationship<TestEntity1?, NoMetadata, NoLinks>?
+			let optionalNullableOne: ToOneRelationship<TestEntity1?, NoIdMetadata, NoMetadata, NoLinks>?
 
-			let optionalMany: ToManyRelationship<TestEntity1, NoMetadata, NoLinks>?
+			let optionalMany: ToManyRelationship<TestEntity1, NoIdMetadata, NoMetadata, NoLinks>?
 		}
 	}
 

--- a/documentation/client-server-example.md
+++ b/documentation/client-server-example.md
@@ -26,8 +26,8 @@ typealias UnidentifiedJSONEntity<Description: ResourceObjectDescription> = JSONA
 // Create relationship typealiases because we do not expect
 // JSON:API Relationships for this particular API to have
 // Metadata or Links associated with them.
-typealias ToOneRelationship<Entity: JSONAPIIdentifiable> = JSONAPI.ToOneRelationship<Entity, NoMetadata, NoLinks>
-typealias ToManyRelationship<Entity: Relatable> = JSONAPI.ToManyRelationship<Entity, NoMetadata, NoLinks>
+typealias ToOneRelationship<Entity: JSONAPIIdentifiable> = JSONAPI.ToOneRelationship<Entity, NoIdMetadata, NoMetadata, NoLinks>
+typealias ToManyRelationship<Entity: Relatable> = JSONAPI.ToManyRelationship<Entity, NoIdMetadata, NoMetadata, NoLinks>
 
 // Create a typealias for a Document because we do not expect
 // JSON:API Documents for this particular API to have Metadata, Links,

--- a/documentation/project-status.md
+++ b/documentation/project-status.md
@@ -22,6 +22,11 @@
 - [x] `links`
 - [x] `meta`
 
+##### Resource Identifier Object
+- [x] `id`
+- [x] `type`
+- [x] `meta`
+
 #### Links Object
 - [x] `href`
 - [x] `meta`

--- a/documentation/usage.md
+++ b/documentation/usage.md
@@ -57,7 +57,7 @@ enum PersonDescription: ResourceObjectDescription {
 	}
 
 	struct Relationships: JSONAPI.Relationships {
-		let friends: ToManyRelationship<Person>
+		let friends: ToManyRelationship<Person, NoIdMetadata, NoMetadata, NoLinks>
 	}
 }
 ```
@@ -153,9 +153,16 @@ In addition to identifying resource objects by ID and type, `Relationships` can 
 
 The `MetaRelationship` is special in that it represents a Relationship Object with no `data` (it must contain at least one of `meta` or `links`). The other two relationship types are Relationship Objects with either singular resource linkages (`ToOneRelationship`) or arrays of resource linkages (`ToManyRelationship`).
 
-To describe a relationship that may be omitted (i.e. the key is not even present in the JSON object), you make the entire `MetaRelationship`, `ToOneRelationship` or `ToManyRelationship` optional. A `ToOneRelationship` can be marked as nullable (i.e. the value could be either `null` or a resource identifier) like this:
+To describe a relationship that may be omitted (i.e. the key is not even present in the JSON object), you make the entire `MetaRelationship`, `ToOneRelationship` or `ToManyRelationship` optional. 
 ```swift
-let nullableRelative: ToOneRelationship<Person?, NoMetadata, NoLinks>
+// note the question mark at the very end of the line.
+let optionalRelative: ToOneRelationship<Person, NoIdMetadata, NoMetadata, NoLinks>?
+```
+
+A `ToOneRelationship` can be marked as nullable (i.e. the value could be either `null` or a resource identifier) like this:
+```swift
+// note the question mark just after `Person`.
+let nullableRelative: ToOneRelationship<Person?, NoIdMetadata, NoMetadata, NoLinks>
 ```
 
 A `ToManyRelationship` can naturally represent the absence of related values with an empty array, so `ToManyRelationship` do not support nullability.

--- a/documentation/usage.md
+++ b/documentation/usage.md
@@ -151,6 +151,41 @@ There are three types of `Relationships`: `MetaRelationship`, `ToOneRelationship
 
 In addition to identifying resource objects by ID and type, `Relationships` can contain `Meta` or `Links` that follow the same rules as [`Meta`](#jsonapimeta) and [`Links`](#jsonapilinks) elsewhere in the JSON:API Document.
 
+Metadata can be specified both in the Relationship Object and in the Resource Identifier Object. You specify the two types of metadata differently. As always, you can use `NoMetadata` to indicate you do not intend the JSON:API relationship to contain metadata.
+
+```swift
+// No metadata in the Resource Identifer or the Relationship:
+// {
+//   "data" : {
+//     "id" : "1234",
+//     "type": "people"
+//   }
+// }
+let relationship1: ToOneRelationship<Person, NoIdMetadata, NoMetadata, NoLinks>
+
+// No metadata in the Resource Identifier but some metadata in the Relationship:
+// {
+//   "data" : {
+//     "id" : "1234",
+//     "type": "people"
+//   },
+//   "meta": { ... }
+// }
+let relationship2: ToOneRelationship<Person, NoIdMetadata, RelMetadata, NoLinks>
+// ^ assumes `RelMetadata` is a `Codable` struct defined elsewhere
+
+// Metadata in the Resource Identifier but not the Relationship:
+// {
+//   "data" : {
+//     "id" : "1234",
+//     "type": "people",
+//     "meta": { ... }
+//   }
+// }
+let relationship3: ToOneRelationship<Person, CoolMetadata, NoMetadata, NoLinks>
+// ^ assumes `CoolMetadata` is a `Codable` struct defined elsewhere
+```
+
 The `MetaRelationship` is special in that it represents a Relationship Object with no `data` (it must contain at least one of `meta` or `links`). The other two relationship types are Relationship Objects with either singular resource linkages (`ToOneRelationship`) or arrays of resource linkages (`ToManyRelationship`).
 
 To describe a relationship that may be omitted (i.e. the key is not even present in the JSON object), you make the entire `MetaRelationship`, `ToOneRelationship` or `ToManyRelationship` optional. 


### PR DESCRIPTION
Closes https://github.com/mattpolzin/JSONAPI/issues/82.

Implementation of metadata within the Resource Identifier Object of a Relationship Object.

This will be a major version bump of the JSON:API library so I should think on what else I would like to change while I am at it.

Todo:
- [x] test coverage
- [x] documentation
- [x] what unrelated changes to make with major version bump?