### PR TITLE
Clearer include failure errors

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,7 +3,7 @@
     "pins": [
       {
         "package": "Poly",
-        "repositoryURL": "https://github.com/mattpolzin/Poly",
+        "repositoryURL": "https://github.com/mattpolzin/Poly.git",
         "state": {
           "branch": null,
           "revision": "36ba3f624bffa34f5f9b9c7648eab3cfdcab4748",

--- a/Sources/JSONAPI/Document/Includes.swift
+++ b/Sources/JSONAPI/Document/Includes.swift
@@ -254,7 +254,7 @@ public struct IncludeDecodingError: Swift.Error, Equatable, CustomStringConverti
         return failures
             .enumerated()
             .map {
-                "\nCould not have been Include Type \($0.offset + 1) because:\n\($0.element)"
+                "\nCould not have been Include Type `\($0.element.resourceObjectJsonAPIType)` because:\n\($0.element)"
         }.joined(separator: "\n")
     }
 }

--- a/Sources/JSONAPI/Resource/Resource Object/ResourceObject.swift
+++ b/Sources/JSONAPI/Resource/Resource Object/ResourceObject.swift
@@ -398,7 +398,7 @@ public extension ResourceObject {
         do {
             type = try container.decode(String.self, forKey: .type)
         } catch let error as DecodingError {
-            throw ResourceObjectDecodingError(error)
+            throw ResourceObjectDecodingError(error, jsonAPIType: Self.jsonType)
                 ?? error
         }
 
@@ -417,13 +417,14 @@ public extension ResourceObject {
                 ?? container.decodeIfPresent(Description.Attributes.self, forKey: .attributes)
                 ?? Description.Attributes(from: EmptyObjectDecoder())
         } catch let decodingError as DecodingError {
-            throw ResourceObjectDecodingError(decodingError)
+            throw ResourceObjectDecodingError(decodingError, jsonAPIType: Self.jsonType)
                 ?? decodingError
         } catch _ as EmptyObjectDecodingError {
             throw ResourceObjectDecodingError(
                 subjectName: ResourceObjectDecodingError.entireObject,
                 cause: .keyNotFound,
-                location: .attributes
+                location: .attributes,
+                jsonAPIType: Self.jsonType
             )
         }
 
@@ -432,16 +433,17 @@ public extension ResourceObject {
                 ?? container.decodeIfPresent(Description.Relationships.self, forKey: .relationships)
                 ?? Description.Relationships(from: EmptyObjectDecoder())
         } catch let decodingError as DecodingError {
-            throw ResourceObjectDecodingError(decodingError)
+            throw ResourceObjectDecodingError(decodingError, jsonAPIType: Self.jsonType)
                 ?? decodingError
         } catch let decodingError as JSONAPICodingError {
-            throw ResourceObjectDecodingError(decodingError)
+            throw ResourceObjectDecodingError(decodingError, jsonAPIType: Self.jsonType)
                 ?? decodingError
         } catch _ as EmptyObjectDecodingError {
             throw ResourceObjectDecodingError(
                 subjectName: ResourceObjectDecodingError.entireObject,
                 cause: .keyNotFound,
-                location: .relationships
+                location: .relationships,
+                jsonAPIType: Self.jsonType
             )
         }
 

--- a/Sources/JSONAPI/Resource/Resource Object/ResourceObjectDecodingError.swift
+++ b/Sources/JSONAPI/Resource/Resource Object/ResourceObjectDecodingError.swift
@@ -6,6 +6,7 @@
 //
 
 public struct ResourceObjectDecodingError: Swift.Error, Equatable {
+    public let resourceObjectJsonAPIType: String
     public let subjectName: String
     public let cause: Cause
     public let location: Location
@@ -16,7 +17,7 @@ public struct ResourceObjectDecodingError: Swift.Error, Equatable {
         case keyNotFound
         case valueNotFound
         case typeMismatch(expectedTypeName: String)
-        case jsonTypeMismatch(expectedType: String, foundType: String)
+        case jsonTypeMismatch(foundType: String)
         case quantityMismatch(expected: JSONAPICodingError.Quantity)
     }
 
@@ -38,7 +39,8 @@ public struct ResourceObjectDecodingError: Swift.Error, Equatable {
         }
     }
 
-    init?(_ decodingError: DecodingError) {
+    init?(_ decodingError: DecodingError, jsonAPIType: String) {
+        self.resourceObjectJsonAPIType = jsonAPIType
         switch decodingError {
         case .typeMismatch(let expectedType, let ctx):
             (location, subjectName) = Self.context(ctx)
@@ -67,11 +69,12 @@ public struct ResourceObjectDecodingError: Swift.Error, Equatable {
         }
     }
 
-    init?(_ jsonAPIError: JSONAPICodingError) {
+    init?(_ jsonAPIError: JSONAPICodingError, jsonAPIType: String) {
+        self.resourceObjectJsonAPIType = jsonAPIType
         switch jsonAPIError {
         case .typeMismatch(expected: let expected, found: let found, path: let path):
             (location, subjectName) = Self.context(path: path)
-            cause = .jsonTypeMismatch(expectedType: expected, foundType: found)
+            cause = .jsonTypeMismatch(foundType: found)
         case .quantityMismatch(expected: let expected, path: let path):
             (location, subjectName) = Self.context(path: path)
             cause = .quantityMismatch(expected: expected)
@@ -81,12 +84,14 @@ public struct ResourceObjectDecodingError: Swift.Error, Equatable {
     }
 
     init(expectedJSONAPIType: String, found: String) {
+        resourceObjectJsonAPIType = expectedJSONAPIType
         location = .type
         subjectName = "self"
-        cause = .jsonTypeMismatch(expectedType: expectedJSONAPIType, foundType: found)
+        cause = .jsonTypeMismatch(foundType: found)
     }
 
-    init(subjectName: String, cause: Cause, location: Location) {
+    init(subjectName: String, cause: Cause, location: Location, jsonAPIType: String) {
+        self.resourceObjectJsonAPIType = jsonAPIType
         self.subjectName = subjectName
         self.cause = cause
         self.location = location
@@ -135,10 +140,10 @@ extension ResourceObjectDecodingError: CustomStringConvertible {
             return "'\(location.singular)' (a.k.a. the JSON:API type name) is not a \(expected) as expected."
         case .typeMismatch(expectedTypeName: let expected):
             return "'\(subjectName)' \(location.singular) is not a \(expected) as expected."
-        case .jsonTypeMismatch(expectedType: let expected, foundType: let found) where location == .type:
-            return "found JSON:API type \"\(found)\" but expected \"\(expected)\""
-        case .jsonTypeMismatch(expectedType: let expected, foundType: let found):
-            return "'\(subjectName)' \(location.singular) is of JSON:API type \"\(found)\" but it was expected to be \"\(expected)\""
+        case .jsonTypeMismatch(foundType: let found) where location == .type:
+            return "found JSON:API type \"\(found)\" but expected \"\(resourceObjectJsonAPIType)\""
+        case .jsonTypeMismatch(foundType: let found):
+            return "'\(subjectName)' \(location.singular) is of JSON:API type \"\(found)\" but it was expected to be \"\(resourceObjectJsonAPIType)\""
         case .quantityMismatch(expected: let expected):
             let expecation: String = {
                 switch expected {

--- a/Sources/JSONAPI/Resource/Resource Object/ResourceObjectDecodingError.swift
+++ b/Sources/JSONAPI/Resource/Resource Object/ResourceObjectDecodingError.swift
@@ -19,6 +19,11 @@ public struct ResourceObjectDecodingError: Swift.Error, Equatable {
         case typeMismatch(expectedTypeName: String)
         case jsonTypeMismatch(foundType: String)
         case quantityMismatch(expected: JSONAPICodingError.Quantity)
+
+        internal var isTypeMismatch: Bool {
+            guard case .jsonTypeMismatch = self else { return false}
+            return true
+        }
     }
 
     public enum Location: String, Equatable {

--- a/Tests/JSONAPITests/Document/DocumentDecodingErrorTests.swift
+++ b/Tests/JSONAPITests/Document/DocumentDecodingErrorTests.swift
@@ -114,10 +114,10 @@ final class DocumentDecodingErrorTests: XCTestCase {
                 String(describing: error),
                 #"""
                 Out of 3 includes, the 3rd one failed to parse: 
-                Could not have been Include Type 1 because:
+                Could not have been Include Type `articles` because:
                 found JSON:API type "not_an_author" but expected "articles"
 
-                Could not have been Include Type 2 because:
+                Could not have been Include Type `authors` because:
                 found JSON:API type "not_an_author" but expected "authors"
                 """#
             )
@@ -142,10 +142,10 @@ final class DocumentDecodingErrorTests: XCTestCase {
                 String(describing: error),
                 #"""
                 Out of 3 includes, the 2nd one failed to parse: 
-                Could not have been Include Type 1 because:
+                Could not have been Include Type `articles` because:
                 found JSON:API type "not_an_author" but expected "articles"
 
-                Could not have been Include Type 2 because:
+                Could not have been Include Type `authors` because:
                 found JSON:API type "not_an_author" but expected "authors"
                 """#
             )

--- a/Tests/JSONAPITests/Document/DocumentDecodingErrorTests.swift
+++ b/Tests/JSONAPITests/Document/DocumentDecodingErrorTests.swift
@@ -92,7 +92,7 @@ final class DocumentDecodingErrorTests: XCTestCase {
                     return
             }
 
-            XCTAssertEqual(String(describing: error), #"Out of 3 includes, the 3rd one failed to parse: found JSON:API type "not_an_author" but expected "authors""#)
+            XCTAssertEqual(String(describing: error), #"Out of the 3 includes in the document, the 3rd one failed to parse: found JSON:API type "not_an_author" but expected "authors""#)
         }
     }
 
@@ -112,14 +112,7 @@ final class DocumentDecodingErrorTests: XCTestCase {
 
             XCTAssertEqual(
                 String(describing: error),
-                #"""
-                Out of 3 includes, the 3rd one failed to parse: 
-                Could not have been Include Type `articles` because:
-                found JSON:API type "not_an_author" but expected "articles"
-
-                Could not have been Include Type `authors` because:
-                found JSON:API type "not_an_author" but expected "authors"
-                """#
+                "Out of the 3 includes in the document, the 3rd one failed to parse: Found JSON:API type 'not_an_author' but expected one of 'articles', 'authors'"
             )
         }
     }
@@ -140,14 +133,7 @@ final class DocumentDecodingErrorTests: XCTestCase {
 
             XCTAssertEqual(
                 String(describing: error),
-                #"""
-                Out of 3 includes, the 2nd one failed to parse: 
-                Could not have been Include Type `articles` because:
-                found JSON:API type "not_an_author" but expected "articles"
-
-                Could not have been Include Type `authors` because:
-                found JSON:API type "not_an_author" but expected "authors"
-                """#
+                "Out of the 3 includes in the document, the 2nd one failed to parse: Found JSON:API type 'not_an_author' but expected one of 'articles', 'authors'"
             )
         }
     }

--- a/Tests/JSONAPITests/Document/stubs/DocumentStubs.swift
+++ b/Tests/JSONAPITests/Document/stubs/DocumentStubs.swift
@@ -289,6 +289,37 @@ let single_document_some_includes_wrong_type = """
 }
 """.data(using: .utf8)!
 
+let single_document_some_includes_wrong_type2 = """
+{
+    "data": {
+        "id": "1",
+        "type": "articles",
+        "relationships": {
+            "author": {
+                "data": {
+                    "type": "authors",
+                    "id": "33"
+                }
+            }
+        }
+    },
+    "included": [
+        {
+            "id": "30",
+            "type": "authors"
+        },
+        {
+            "id": "31",
+            "type": "not_an_author"
+        },
+        {
+            "id": "33",
+            "type": "authors"
+        }
+    ]
+}
+""".data(using: .utf8)!
+
 let single_document_some_includes_with_api_description = """
 {
 	"data": {

--- a/Tests/JSONAPITests/Includes/IncludesDecodingErrorTests.swift
+++ b/Tests/JSONAPITests/Includes/IncludesDecodingErrorTests.swift
@@ -10,7 +10,6 @@ import JSONAPI
 
 final class IncludesDecodingErrorTests: XCTestCase {
     func test_unexpectedIncludeType() {
-        var error1: Error!
         XCTAssertThrowsError(try testDecoder.decode(Includes<Include2<TestEntity, TestEntity2>>.self, from: three_different_type_includes)) { (error: Error) -> Void in
             XCTAssertEqual(
                 (error as? IncludesDecodingError)?.idx,
@@ -19,23 +18,69 @@ final class IncludesDecodingErrorTests: XCTestCase {
 
             XCTAssertEqual(
                 (error as? IncludesDecodingError).map(String.init(describing:)),
-"""
-Include 3 failed to parse: \nCould not have been Include Type 1 because:
-found JSON:API type "test_entity4" but expected "test_entity1"
+                """
+                Out of 3 includes, the 3rd one failed to parse: \nCould not have been Include Type 1 because:
+                found JSON:API type "test_entity4" but expected "test_entity1"
 
-Could not have been Include Type 2 because:
-found JSON:API type "test_entity4" but expected "test_entity2"
-"""
+                Could not have been Include Type 2 because:
+                found JSON:API type "test_entity4" but expected "test_entity2"
+                """
             )
-
-            error1 = error
         }
 
-        // now test that we get the same error from a different test stub
+        // now test that we get the same error with a different total include count from a different test stub
         XCTAssertThrowsError(try testDecoder.decode(Includes<Include2<TestEntity, TestEntity2>>.self, from: four_different_type_includes)) { (error2: Error) -> Void in
             XCTAssertEqual(
-                error1 as? IncludesDecodingError,
-                error2 as? IncludesDecodingError
+                (error2 as? IncludesDecodingError).map(String.init(describing:)),
+                """
+                Out of 4 includes, the 3rd one failed to parse: \nCould not have been Include Type 1 because:
+                found JSON:API type "test_entity4" but expected "test_entity1"
+
+                Could not have been Include Type 2 because:
+                found JSON:API type "test_entity4" but expected "test_entity2"
+                """
+            )
+        }
+
+        // and with six total includes
+        XCTAssertThrowsError(try testDecoder.decode(Includes<Include2<TestEntity, TestEntity2>>.self, from: six_includes_one_bad_type)) { (error2: Error) -> Void in
+            XCTAssertEqual(
+                (error2 as? IncludesDecodingError).map(String.init(describing:)),
+                """
+                Out of 6 includes, the 5th one failed to parse: \nCould not have been Include Type 1 because:
+                found JSON:API type "test_entity4" but expected "test_entity1"
+
+                Could not have been Include Type 2 because:
+                found JSON:API type "test_entity4" but expected "test_entity2"
+                """
+            )
+        }
+
+        // and with a number of total includes between 10 and 19
+        XCTAssertThrowsError(try testDecoder.decode(Includes<Include2<TestEntity, TestEntity2>>.self, from: eleven_includes_one_bad_type)) { (error2: Error) -> Void in
+            XCTAssertEqual(
+                (error2 as? IncludesDecodingError).map(String.init(describing:)),
+                """
+                Out of 11 includes, the 10th one failed to parse: \nCould not have been Include Type 1 because:
+                found JSON:API type "test_entity4" but expected "test_entity1"
+
+                Could not have been Include Type 2 because:
+                found JSON:API type "test_entity4" but expected "test_entity2"
+                """
+            )
+        }
+
+        // and finally with a larger number of total includes
+        XCTAssertThrowsError(try testDecoder.decode(Includes<Include2<TestEntity, TestEntity2>>.self, from: twenty_two_includes_one_bad_type)) { (error2: Error) -> Void in
+            XCTAssertEqual(
+                (error2 as? IncludesDecodingError).map(String.init(describing:)),
+                """
+                Out of 22 includes, the 21st one failed to parse: \nCould not have been Include Type 1 because:
+                found JSON:API type "test_entity4" but expected "test_entity1"
+
+                Could not have been Include Type 2 because:
+                found JSON:API type "test_entity4" but expected "test_entity2"
+                """
             )
         }
     }

--- a/Tests/JSONAPITests/Includes/IncludesDecodingErrorTests.swift
+++ b/Tests/JSONAPITests/Includes/IncludesDecodingErrorTests.swift
@@ -19,10 +19,10 @@ final class IncludesDecodingErrorTests: XCTestCase {
             XCTAssertEqual(
                 (error as? IncludesDecodingError).map(String.init(describing:)),
                 """
-                Out of 3 includes, the 3rd one failed to parse: \nCould not have been Include Type 1 because:
+                Out of 3 includes, the 3rd one failed to parse: \nCould not have been Include Type `test_entity1` because:
                 found JSON:API type "test_entity4" but expected "test_entity1"
 
-                Could not have been Include Type 2 because:
+                Could not have been Include Type `test_entity2` because:
                 found JSON:API type "test_entity4" but expected "test_entity2"
                 """
             )
@@ -33,10 +33,10 @@ final class IncludesDecodingErrorTests: XCTestCase {
             XCTAssertEqual(
                 (error2 as? IncludesDecodingError).map(String.init(describing:)),
                 """
-                Out of 4 includes, the 3rd one failed to parse: \nCould not have been Include Type 1 because:
+                Out of 4 includes, the 3rd one failed to parse: \nCould not have been Include Type `test_entity1` because:
                 found JSON:API type "test_entity4" but expected "test_entity1"
 
-                Could not have been Include Type 2 because:
+                Could not have been Include Type `test_entity2` because:
                 found JSON:API type "test_entity4" but expected "test_entity2"
                 """
             )
@@ -47,10 +47,10 @@ final class IncludesDecodingErrorTests: XCTestCase {
             XCTAssertEqual(
                 (error2 as? IncludesDecodingError).map(String.init(describing:)),
                 """
-                Out of 6 includes, the 5th one failed to parse: \nCould not have been Include Type 1 because:
+                Out of 6 includes, the 5th one failed to parse: \nCould not have been Include Type `test_entity1` because:
                 found JSON:API type "test_entity4" but expected "test_entity1"
 
-                Could not have been Include Type 2 because:
+                Could not have been Include Type `test_entity2` because:
                 found JSON:API type "test_entity4" but expected "test_entity2"
                 """
             )
@@ -61,10 +61,10 @@ final class IncludesDecodingErrorTests: XCTestCase {
             XCTAssertEqual(
                 (error2 as? IncludesDecodingError).map(String.init(describing:)),
                 """
-                Out of 11 includes, the 10th one failed to parse: \nCould not have been Include Type 1 because:
+                Out of 11 includes, the 10th one failed to parse: \nCould not have been Include Type `test_entity1` because:
                 found JSON:API type "test_entity4" but expected "test_entity1"
 
-                Could not have been Include Type 2 because:
+                Could not have been Include Type `test_entity2` because:
                 found JSON:API type "test_entity4" but expected "test_entity2"
                 """
             )
@@ -75,10 +75,10 @@ final class IncludesDecodingErrorTests: XCTestCase {
             XCTAssertEqual(
                 (error2 as? IncludesDecodingError).map(String.init(describing:)),
                 """
-                Out of 22 includes, the 21st one failed to parse: \nCould not have been Include Type 1 because:
+                Out of 22 includes, the 21st one failed to parse: \nCould not have been Include Type `test_entity1` because:
                 found JSON:API type "test_entity4" but expected "test_entity1"
 
-                Could not have been Include Type 2 because:
+                Could not have been Include Type `test_entity2` because:
                 found JSON:API type "test_entity4" but expected "test_entity2"
                 """
             )

--- a/Tests/JSONAPITests/Includes/IncludesDecodingErrorTests.swift
+++ b/Tests/JSONAPITests/Includes/IncludesDecodingErrorTests.swift
@@ -84,6 +84,29 @@ final class IncludesDecodingErrorTests: XCTestCase {
             )
         }
     }
+
+    func test_missingProperty() {
+        XCTAssertThrowsError(
+            try testDecoder.decode(
+                Includes<Include3<TestEntity, TestEntity2, TestEntity4>>.self,
+                from: three_includes_one_missing_attributes
+            )
+        ) { (error: Error) -> Void in
+            XCTAssertEqual(
+                (error as? IncludesDecodingError).map(String.init(describing:)),
+                """
+                Out of 3 includes, the 3rd one failed to parse: \nCould not have been Include Type `test_entity1` because:
+                found JSON:API type "test_entity2" but expected "test_entity1"
+
+                Could not have been Include Type `test_entity2` because:
+                'foo' attribute is required and missing.
+
+                Could not have been Include Type `test_entity4` because:
+                found JSON:API type "test_entity2" but expected "test_entity4"
+                """
+            )
+        }
+    }
 }
 
 // MARK: - Test Types

--- a/Tests/JSONAPITests/Includes/IncludesDecodingErrorTests.swift
+++ b/Tests/JSONAPITests/Includes/IncludesDecodingErrorTests.swift
@@ -18,13 +18,7 @@ final class IncludesDecodingErrorTests: XCTestCase {
 
             XCTAssertEqual(
                 (error as? IncludesDecodingError).map(String.init(describing:)),
-                """
-                Out of 3 includes, the 3rd one failed to parse: \nCould not have been Include Type `test_entity1` because:
-                found JSON:API type "test_entity4" but expected "test_entity1"
-
-                Could not have been Include Type `test_entity2` because:
-                found JSON:API type "test_entity4" but expected "test_entity2"
-                """
+                "Out of the 3 includes in the document, the 3rd one failed to parse: Found JSON:API type 'test_entity4' but expected one of 'test_entity1', 'test_entity2'"
             )
         }
 
@@ -32,13 +26,7 @@ final class IncludesDecodingErrorTests: XCTestCase {
         XCTAssertThrowsError(try testDecoder.decode(Includes<Include2<TestEntity, TestEntity2>>.self, from: four_different_type_includes)) { (error2: Error) -> Void in
             XCTAssertEqual(
                 (error2 as? IncludesDecodingError).map(String.init(describing:)),
-                """
-                Out of 4 includes, the 3rd one failed to parse: \nCould not have been Include Type `test_entity1` because:
-                found JSON:API type "test_entity4" but expected "test_entity1"
-
-                Could not have been Include Type `test_entity2` because:
-                found JSON:API type "test_entity4" but expected "test_entity2"
-                """
+                "Out of the 4 includes in the document, the 3rd one failed to parse: Found JSON:API type 'test_entity4' but expected one of 'test_entity1', 'test_entity2'"
             )
         }
 
@@ -46,13 +34,7 @@ final class IncludesDecodingErrorTests: XCTestCase {
         XCTAssertThrowsError(try testDecoder.decode(Includes<Include2<TestEntity, TestEntity2>>.self, from: six_includes_one_bad_type)) { (error2: Error) -> Void in
             XCTAssertEqual(
                 (error2 as? IncludesDecodingError).map(String.init(describing:)),
-                """
-                Out of 6 includes, the 5th one failed to parse: \nCould not have been Include Type `test_entity1` because:
-                found JSON:API type "test_entity4" but expected "test_entity1"
-
-                Could not have been Include Type `test_entity2` because:
-                found JSON:API type "test_entity4" but expected "test_entity2"
-                """
+                "Out of the 6 includes in the document, the 5th one failed to parse: Found JSON:API type 'test_entity4' but expected one of 'test_entity1', 'test_entity2'"
             )
         }
 
@@ -60,13 +42,7 @@ final class IncludesDecodingErrorTests: XCTestCase {
         XCTAssertThrowsError(try testDecoder.decode(Includes<Include2<TestEntity, TestEntity2>>.self, from: eleven_includes_one_bad_type)) { (error2: Error) -> Void in
             XCTAssertEqual(
                 (error2 as? IncludesDecodingError).map(String.init(describing:)),
-                """
-                Out of 11 includes, the 10th one failed to parse: \nCould not have been Include Type `test_entity1` because:
-                found JSON:API type "test_entity4" but expected "test_entity1"
-
-                Could not have been Include Type `test_entity2` because:
-                found JSON:API type "test_entity4" but expected "test_entity2"
-                """
+                "Out of the 11 includes in the document, the 10th one failed to parse: Found JSON:API type 'test_entity4' but expected one of 'test_entity1', 'test_entity2'"
             )
         }
 
@@ -74,13 +50,7 @@ final class IncludesDecodingErrorTests: XCTestCase {
         XCTAssertThrowsError(try testDecoder.decode(Includes<Include2<TestEntity, TestEntity2>>.self, from: twenty_two_includes_one_bad_type)) { (error2: Error) -> Void in
             XCTAssertEqual(
                 (error2 as? IncludesDecodingError).map(String.init(describing:)),
-                """
-                Out of 22 includes, the 21st one failed to parse: \nCould not have been Include Type `test_entity1` because:
-                found JSON:API type "test_entity4" but expected "test_entity1"
-
-                Could not have been Include Type `test_entity2` because:
-                found JSON:API type "test_entity4" but expected "test_entity2"
-                """
+                "Out of the 22 includes in the document, the 21st one failed to parse: Found JSON:API type 'test_entity4' but expected one of 'test_entity1', 'test_entity2'"
             )
         }
     }
@@ -94,16 +64,7 @@ final class IncludesDecodingErrorTests: XCTestCase {
         ) { (error: Error) -> Void in
             XCTAssertEqual(
                 (error as? IncludesDecodingError).map(String.init(describing:)),
-                """
-                Out of 3 includes, the 3rd one failed to parse: \nCould not have been Include Type `test_entity1` because:
-                found JSON:API type "test_entity2" but expected "test_entity1"
-
-                Could not have been Include Type `test_entity2` because:
-                'foo' attribute is required and missing.
-
-                Could not have been Include Type `test_entity4` because:
-                found JSON:API type "test_entity2" but expected "test_entity4"
-                """
+                "Out of the 3 includes in the document, the 3rd one failed to parse: 'foo' attribute is required and missing."
             )
         }
     }

--- a/Tests/JSONAPITests/Includes/stubs/IncludeStubs.swift
+++ b/Tests/JSONAPITests/Includes/stubs/IncludeStubs.swift
@@ -7,65 +7,65 @@
 
 let one_include = """
 [
-{
-"type": "test_entity1",
-"id": "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF",
-"attributes": {
-"foo": "Hello",
-"bar": 123
-}
-}
+    {
+        "type": "test_entity1",
+        "id": "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF",
+        "attributes": {
+            "foo": "Hello",
+            "bar": 123
+        }
+    }
 ]
 """.data(using: .utf8)!
 
 let two_same_type_includes = """
 [
-{
-"type": "test_entity1",
-"id": "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF",
-"attributes": {
-"foo": "Hello",
-"bar": 123
-}
-},
-{
-"type": "test_entity1",
-"id": "90F03B69-4DF1-467F-B52E-B0C9E44FC333",
-"attributes": {
-"foo": "World",
-"bar": 456
-}
-}
+    {
+        "type": "test_entity1",
+        "id": "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF",
+        "attributes": {
+            "foo": "Hello",
+            "bar": 123
+        }
+    },
+        {
+        "type": "test_entity1",
+        "id": "90F03B69-4DF1-467F-B52E-B0C9E44FC333",
+        "attributes": {
+            "foo": "World",
+            "bar": 456
+        }
+    }
 ]
 
 """.data(using: .utf8)!
 
 let two_different_type_includes = """
 [
-{
-"type": "test_entity1",
-"id": "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF",
-"attributes": {
-"foo": "Hello",
-"bar": 123
-}
-},
-{
-"type": "test_entity2",
-"id": "90F03B69-4DF1-467F-B52E-B0C9E44FC333",
-"attributes": {
-"foo": "World",
-"bar": 456
-},
-"relationships": {
-"entity1": {
-"data": {
-"type": "test_entity1",
-"id": "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF"
-}
-}
-}
-}
+    {
+        "type": "test_entity1",
+        "id": "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF",
+        "attributes": {
+            "foo": "Hello",
+            "bar": 123
+        }
+    },
+    {
+        "type": "test_entity2",
+        "id": "90F03B69-4DF1-467F-B52E-B0C9E44FC333",
+        "attributes": {
+            "foo": "World",
+            "bar": 456
+        },
+        "relationships": {
+            "entity1": {
+                "data": {
+                    "type": "test_entity1",
+                    "id": "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF"
+                }
+            }
+        }
+    }
 ]
 
 """.data(using: .utf8)!
@@ -687,6 +687,38 @@ let eleven_different_type_includes = """
 ]
 """.data(using: .utf8)!
 
+
+let three_includes_one_missing_attributes = """
+[
+    {
+        "type": "test_entity1",
+        "id": "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF",
+        "attributes": {
+            "foo": "Hello",
+            "bar": 123
+        }
+    },
+    {
+        "type": "test_entity4",
+        "id": "364B3B69-4DF1-467F-B52E-B0C9E44F666E"
+    },
+    {
+        "type": "test_entity2",
+        "id": "90F03B69-4DF1-467F-B52E-B0C9E44FC333",
+        "attributes": {
+            "bar": 456
+        },
+        "relationships": {
+            "entity1": {
+                "data": {
+                    "type": "test_entity1",
+                    "id": "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF"
+                }
+            }
+        }
+    }
+]
+""".data(using: .utf8)!
 
 let six_includes_one_bad_type = """
 [

--- a/Tests/JSONAPITests/Includes/stubs/IncludeStubs.swift
+++ b/Tests/JSONAPITests/Includes/stubs/IncludeStubs.swift
@@ -686,3 +686,355 @@ let eleven_different_type_includes = """
     }
 ]
 """.data(using: .utf8)!
+
+
+let six_includes_one_bad_type = """
+[
+{
+        "type": "test_entity1",
+        "id": "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF",
+        "attributes": {
+            "foo": "Hello",
+            "bar": 123
+        }
+    },
+{
+        "type": "test_entity1",
+        "id": "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF",
+        "attributes": {
+            "foo": "Hello",
+            "bar": 123
+        }
+    },
+{
+        "type": "test_entity1",
+        "id": "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF",
+        "attributes": {
+            "foo": "Hello",
+            "bar": 123
+        }
+    },
+    {
+        "type": "test_entity2",
+        "id": "90F03B69-4DF1-467F-B52E-B0C9E44FC333",
+        "attributes": {
+            "foo": "World",
+            "bar": 456
+        },
+        "relationships": {
+            "entity1": {
+                "data": {
+                    "type": "test_entity1",
+                    "id": "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF"
+                }
+            }
+        }
+    },
+    {
+        "type": "test_entity4",
+        "id": "364B3B69-4DF1-467F-B52E-B0C9E44F666E"
+    },
+    {
+        "type": "test_entity6",
+        "id": "11113B69-4DF1-467F-B52E-B0C9E44FC444",
+        "relationships": {
+            "entity4": {
+                "data": {
+                    "type": "test_entity4",
+                    "id": "364B3B69-4DF1-467F-B52E-B0C9E44F666E"
+                }
+            }
+        }
+    }
+]
+""".data(using: .utf8)!
+
+let eleven_includes_one_bad_type = """
+[
+{
+        "type": "test_entity1",
+        "id": "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF",
+        "attributes": {
+            "foo": "Hello",
+            "bar": 123
+        }
+    },
+{
+        "type": "test_entity1",
+        "id": "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF",
+        "attributes": {
+            "foo": "Hello",
+            "bar": 123
+        }
+    },
+{
+        "type": "test_entity1",
+        "id": "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF",
+        "attributes": {
+            "foo": "Hello",
+            "bar": 123
+        }
+    },
+{
+        "type": "test_entity1",
+        "id": "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF",
+        "attributes": {
+            "foo": "Hello",
+            "bar": 123
+        }
+    },
+{
+        "type": "test_entity1",
+        "id": "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF",
+        "attributes": {
+            "foo": "Hello",
+            "bar": 123
+        }
+    },
+{
+        "type": "test_entity1",
+        "id": "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF",
+        "attributes": {
+            "foo": "Hello",
+            "bar": 123
+        }
+    },
+{
+        "type": "test_entity1",
+        "id": "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF",
+        "attributes": {
+            "foo": "Hello",
+            "bar": 123
+        }
+    },
+{
+        "type": "test_entity1",
+        "id": "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF",
+        "attributes": {
+            "foo": "Hello",
+            "bar": 123
+        }
+    },
+    {
+        "type": "test_entity2",
+        "id": "90F03B69-4DF1-467F-B52E-B0C9E44FC333",
+        "attributes": {
+            "foo": "World",
+            "bar": 456
+        },
+        "relationships": {
+            "entity1": {
+                "data": {
+                    "type": "test_entity1",
+                    "id": "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF"
+                }
+            }
+        }
+    },
+    {
+        "type": "test_entity4",
+        "id": "364B3B69-4DF1-467F-B52E-B0C9E44F666E"
+    },
+    {
+        "type": "test_entity6",
+        "id": "11113B69-4DF1-467F-B52E-B0C9E44FC444",
+        "relationships": {
+            "entity4": {
+                "data": {
+                    "type": "test_entity4",
+                    "id": "364B3B69-4DF1-467F-B52E-B0C9E44F666E"
+                }
+            }
+        }
+    }
+]
+""".data(using: .utf8)!
+
+let twenty_two_includes_one_bad_type = """
+[
+{
+        "type": "test_entity1",
+        "id": "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF",
+        "attributes": {
+            "foo": "Hello",
+            "bar": 123
+        }
+    },
+{
+        "type": "test_entity1",
+        "id": "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF",
+        "attributes": {
+            "foo": "Hello",
+            "bar": 123
+        }
+    },
+{
+        "type": "test_entity1",
+        "id": "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF",
+        "attributes": {
+            "foo": "Hello",
+            "bar": 123
+        }
+    },
+{
+        "type": "test_entity1",
+        "id": "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF",
+        "attributes": {
+            "foo": "Hello",
+            "bar": 123
+        }
+    },
+{
+        "type": "test_entity1",
+        "id": "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF",
+        "attributes": {
+            "foo": "Hello",
+            "bar": 123
+        }
+    },
+{
+        "type": "test_entity1",
+        "id": "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF",
+        "attributes": {
+            "foo": "Hello",
+            "bar": 123
+        }
+    },
+{
+        "type": "test_entity1",
+        "id": "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF",
+        "attributes": {
+            "foo": "Hello",
+            "bar": 123
+        }
+    },
+{
+        "type": "test_entity1",
+        "id": "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF",
+        "attributes": {
+            "foo": "Hello",
+            "bar": 123
+        }
+    },
+{
+        "type": "test_entity1",
+        "id": "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF",
+        "attributes": {
+            "foo": "Hello",
+            "bar": 123
+        }
+    },
+{
+        "type": "test_entity1",
+        "id": "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF",
+        "attributes": {
+            "foo": "Hello",
+            "bar": 123
+        }
+    },
+{
+        "type": "test_entity1",
+        "id": "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF",
+        "attributes": {
+            "foo": "Hello",
+            "bar": 123
+        }
+    },
+{
+        "type": "test_entity1",
+        "id": "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF",
+        "attributes": {
+            "foo": "Hello",
+            "bar": 123
+        }
+    },
+{
+        "type": "test_entity1",
+        "id": "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF",
+        "attributes": {
+            "foo": "Hello",
+            "bar": 123
+        }
+    },
+{
+        "type": "test_entity1",
+        "id": "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF",
+        "attributes": {
+            "foo": "Hello",
+            "bar": 123
+        }
+    },
+{
+        "type": "test_entity1",
+        "id": "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF",
+        "attributes": {
+            "foo": "Hello",
+            "bar": 123
+        }
+    },
+{
+        "type": "test_entity1",
+        "id": "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF",
+        "attributes": {
+            "foo": "Hello",
+            "bar": 123
+        }
+    },
+{
+        "type": "test_entity1",
+        "id": "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF",
+        "attributes": {
+            "foo": "Hello",
+            "bar": 123
+        }
+    },
+{
+        "type": "test_entity1",
+        "id": "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF",
+        "attributes": {
+            "foo": "Hello",
+            "bar": 123
+        }
+    },
+{
+        "type": "test_entity1",
+        "id": "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF",
+        "attributes": {
+            "foo": "Hello",
+            "bar": 123
+        }
+    },
+    {
+        "type": "test_entity2",
+        "id": "90F03B69-4DF1-467F-B52E-B0C9E44FC333",
+        "attributes": {
+            "foo": "World",
+            "bar": 456
+        },
+        "relationships": {
+            "entity1": {
+                "data": {
+                    "type": "test_entity1",
+                    "id": "2DF03B69-4B0A-467F-B52E-B0C9E44FCECF"
+                }
+            }
+        }
+    },
+    {
+        "type": "test_entity4",
+        "id": "364B3B69-4DF1-467F-B52E-B0C9E44F666E"
+    },
+    {
+        "type": "test_entity6",
+        "id": "11113B69-4DF1-467F-B52E-B0C9E44FC444",
+        "relationships": {
+            "entity4": {
+                "data": {
+                    "type": "test_entity4",
+                    "id": "364B3B69-4DF1-467F-B52E-B0C9E44F666E"
+                }
+            }
+        }
+    }
+]
+""".data(using: .utf8)!

--- a/Tests/JSONAPITests/ResourceObject/ResourceObjectDecodingErrorTests.swift
+++ b/Tests/JSONAPITests/ResourceObject/ResourceObjectDecodingErrorTests.swift
@@ -20,7 +20,8 @@ final class ResourceObjectDecodingErrorTests: XCTestCase {
                 ResourceObjectDecodingError(
                     subjectName: ResourceObjectDecodingError.entireObject,
                     cause: .keyNotFound,
-                    location: .relationships
+                    location: .relationships,
+                    jsonAPIType: TestEntity.jsonType
                 )
             )
 
@@ -41,7 +42,8 @@ final class ResourceObjectDecodingErrorTests: XCTestCase {
                 ResourceObjectDecodingError(
                     subjectName: "required",
                     cause: .keyNotFound,
-                    location: .relationships
+                    location: .relationships,
+                    jsonAPIType: TestEntity.jsonType
                 )
             )
 
@@ -62,7 +64,8 @@ final class ResourceObjectDecodingErrorTests: XCTestCase {
                 ResourceObjectDecodingError(
                     subjectName: "required",
                     cause: .keyNotFound,
-                    location: .relationshipId
+                    location: .relationshipId,
+                    jsonAPIType: TestEntity.jsonType
                 )
             )
 
@@ -83,7 +86,8 @@ final class ResourceObjectDecodingErrorTests: XCTestCase {
                 ResourceObjectDecodingError(
                     subjectName: "required",
                     cause: .keyNotFound,
-                    location: .relationshipType
+                    location: .relationshipType,
+                    jsonAPIType: TestEntity.jsonType
                 )
             )
 
@@ -104,7 +108,8 @@ final class ResourceObjectDecodingErrorTests: XCTestCase {
                 ResourceObjectDecodingError(
                     subjectName: "required",
                     cause: .valueNotFound,
-                    location: .relationships
+                    location: .relationships,
+                    jsonAPIType: TestEntity.jsonType
                 )
             )
 
@@ -125,7 +130,8 @@ final class ResourceObjectDecodingErrorTests: XCTestCase {
                 ResourceObjectDecodingError(
                     subjectName: "required",
                     cause: .valueNotFound,
-                    location: .relationships
+                    location: .relationships,
+                    jsonAPIType: TestEntity.jsonType
                 )
             )
 
@@ -145,8 +151,9 @@ final class ResourceObjectDecodingErrorTests: XCTestCase {
                 error as? ResourceObjectDecodingError,
                 ResourceObjectDecodingError(
                     subjectName: "required",
-                    cause: .jsonTypeMismatch(expectedType: "thirteenth_test_entities", foundType: "not_the_same"),
-                    location: .relationships
+                    cause: .jsonTypeMismatch(foundType: "not_the_same"),
+                    location: .relationships,
+                    jsonAPIType: "thirteenth_test_entities"
                 )
             )
 
@@ -168,7 +175,8 @@ final class ResourceObjectDecodingErrorTests: XCTestCase {
                 ResourceObjectDecodingError(
                     subjectName: "required",
                     cause: .quantityMismatch(expected: .one),
-                    location: .relationships
+                    location: .relationships,
+                    jsonAPIType: TestEntity.jsonType
                 )
             )
 
@@ -187,7 +195,8 @@ final class ResourceObjectDecodingErrorTests: XCTestCase {
                 ResourceObjectDecodingError(
                     subjectName: "omittable",
                     cause: .quantityMismatch(expected: .many),
-                    location: .relationships
+                    location: .relationships,
+                    jsonAPIType: TestEntity.jsonType
                 )
             )
 
@@ -211,7 +220,8 @@ extension ResourceObjectDecodingErrorTests {
                 ResourceObjectDecodingError(
                     subjectName: ResourceObjectDecodingError.entireObject,
                     cause: .keyNotFound,
-                    location: .attributes
+                    location: .attributes,
+                    jsonAPIType: TestEntity2.jsonType
                 )
             )
 
@@ -232,7 +242,8 @@ extension ResourceObjectDecodingErrorTests {
                 ResourceObjectDecodingError(
                     subjectName: "required",
                     cause: .keyNotFound,
-                    location: .attributes
+                    location: .attributes,
+                    jsonAPIType: TestEntity2.jsonType
                 )
             )
 
@@ -253,7 +264,8 @@ extension ResourceObjectDecodingErrorTests {
                 ResourceObjectDecodingError(
                     subjectName: "required",
                     cause: .valueNotFound,
-                    location: .attributes
+                    location: .attributes,
+                    jsonAPIType: TestEntity2.jsonType
                 )
             )
 
@@ -274,7 +286,8 @@ extension ResourceObjectDecodingErrorTests {
                 ResourceObjectDecodingError(
                     subjectName: "required",
                     cause: .typeMismatch(expectedTypeName: String(describing: String.self)),
-                    location: .attributes
+                    location: .attributes,
+                    jsonAPIType: TestEntity2.jsonType
                 )
             )
 
@@ -295,7 +308,8 @@ extension ResourceObjectDecodingErrorTests {
                 ResourceObjectDecodingError(
                     subjectName: "other",
                     cause: .typeMismatch(expectedTypeName: String(describing: Int.self)),
-                    location: .attributes
+                    location: .attributes,
+                    jsonAPIType: TestEntity2.jsonType
                 )
             )
 
@@ -316,7 +330,8 @@ extension ResourceObjectDecodingErrorTests {
                 ResourceObjectDecodingError(
                     subjectName: "yetAnother",
                     cause: .typeMismatch(expectedTypeName: String(describing: Bool.self)),
-                    location: .attributes
+                    location: .attributes,
+                    jsonAPIType: TestEntity2.jsonType
                 )
             )
 
@@ -337,7 +352,8 @@ extension ResourceObjectDecodingErrorTests {
                 ResourceObjectDecodingError(
                     subjectName: "transformed",
                     cause: .typeMismatch(expectedTypeName: String(describing: Int.self)),
-                    location: .attributes
+                    location: .attributes,
+                    jsonAPIType: TestEntity2.jsonType
                 )
             )
 
@@ -372,8 +388,9 @@ extension ResourceObjectDecodingErrorTests {
                 error as? ResourceObjectDecodingError,
                 ResourceObjectDecodingError(
                     subjectName: "self",
-                    cause: .jsonTypeMismatch(expectedType: "fourteenth_test_entities", foundType: "not_correct_type"),
-                    location: .type
+                    cause: .jsonTypeMismatch(foundType: "not_correct_type"),
+                    location: .type,
+                    jsonAPIType: "fourteenth_test_entities"
                 )
             )
 
@@ -394,7 +411,8 @@ extension ResourceObjectDecodingErrorTests {
                 ResourceObjectDecodingError(
                     subjectName: "type",
                     cause: .typeMismatch(expectedTypeName: String(describing: String.self)),
-                    location: .type
+                    location: .type,
+                    jsonAPIType: TestEntity2.jsonType
                 )
             )
 
@@ -415,7 +433,8 @@ extension ResourceObjectDecodingErrorTests {
                 ResourceObjectDecodingError(
                     subjectName: "type",
                     cause: .keyNotFound,
-                    location: .type
+                    location: .type,
+                    jsonAPIType: TestEntity2.jsonType
                 )
             )
 
@@ -436,7 +455,8 @@ extension ResourceObjectDecodingErrorTests {
                 ResourceObjectDecodingError(
                     subjectName: "type",
                     cause: .valueNotFound,
-                    location: .type
+                    location: .type,
+                    jsonAPIType: TestEntity2.jsonType
                 )
             )
 


### PR DESCRIPTION
Closes https://github.com/mattpolzin/JSONAPI/issues/84.

Old messages mentioned the index of the failed include (i.e. of all the includes in the document, which one failed) and also a message for why the given include was not of each possible type of include.

> Include 3 failed to parse:
> Could not have been Include Type 1 because:
> found JSON:API type "not_an_author" but expected "articles"
>
> Could not have been Include Type 2 because:
> found JSON:API type "not_an_author" but expected "authors"

The new message after this PR will display a verbose message like above (with a bit more clarity) if needed but in the common cases of (a) all failures have the wrong JSON:API type or (b) exactly one failure has the correct JSON:API type a much more concise and targeted error message will be generated.