### PR TITLE
Swift 5 4 CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,7 @@ jobs:
           - swift:5.3-focal
           - swift:5.3-centos8
           - swift:5.3-amazonlinux2
+          - swiftlang/swift:nightly-5.4-focal
     container: ${{ matrix.image }}
     steps:
     - name: Checkout code

--- a/Sources/JSONAPI/Resource/Resource Object/ResourceObject+Replacing.swift
+++ b/Sources/JSONAPI/Resource/Resource Object/ResourceObject+Replacing.swift
@@ -15,7 +15,7 @@ public extension JSONAPI.ResourceObject {
     /// - parameters:
     ///     - replacement: A function that takes the existing `attributes` and returns the replacement.
     func replacingAttributes(_ replacement: (Description.Attributes) -> Description.Attributes) -> Self {
-        return Self(id: id,
+        return ResourceObject(id: id,
                     attributes: replacement(attributes),
                     relationships: relationships,
                     meta: meta,

--- a/Sources/JSONAPI/Resource/Resource Object/ResourceObject+Replacing.swift
+++ b/Sources/JSONAPI/Resource/Resource Object/ResourceObject+Replacing.swift
@@ -15,7 +15,7 @@ public extension JSONAPI.ResourceObject {
     /// - parameters:
     ///     - replacement: A function that takes the existing `attributes` and returns the replacement.
     func replacingAttributes(_ replacement: (Description.Attributes) -> Description.Attributes) -> Self {
-        return ResourceObject(id: id,
+        return Self(id: id,
                     attributes: replacement(attributes),
                     relationships: relationships,
                     meta: meta,

--- a/Sources/JSONAPI/Resource/Resource Object/ResourceObject.swift
+++ b/Sources/JSONAPI/Resource/Resource Object/ResourceObject.swift
@@ -167,8 +167,8 @@ extension ResourceObject: JSONAPIIdentifiable, IdentifiableResourceObjectType, R
     public typealias ID = ResourceObject.Id
 }
 
-//@available(OSX 10.15, iOS 13, tvOS 13, watchOS 6, *)
-//extension ResourceObject: Swift.Identifiable where EntityRawIdType: JSONAPI.RawIdType {}
+@available(OSX 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension ResourceObject: Swift.Identifiable where EntityRawIdType: JSONAPI.RawIdType {}
 
 extension ResourceObject: CustomStringConvertible {
     public var description: String {

--- a/Sources/JSONAPI/Resource/Resource Object/ResourceObject.swift
+++ b/Sources/JSONAPI/Resource/Resource Object/ResourceObject.swift
@@ -128,7 +128,7 @@ public struct ResourceObject<Description: JSONAPI.ResourceObjectDescription, Met
     /// the entity is being created clientside and the
     /// server is being asked to create a unique Id. Otherwise,
     /// this should be of a type conforming to `IdType`.
-    public let id: ResourceObject.Id
+    public let id: JSONAPI.Id<EntityRawIdType, Self>
 
     /// The JSON API compliant attributes of this `ResourceObject`.
     public let attributes: Description.Attributes

--- a/Sources/JSONAPI/Resource/Resource Object/ResourceObject.swift
+++ b/Sources/JSONAPI/Resource/Resource Object/ResourceObject.swift
@@ -167,8 +167,8 @@ extension ResourceObject: JSONAPIIdentifiable, IdentifiableResourceObjectType, R
     public typealias ID = ResourceObject.Id
 }
 
-@available(OSX 10.15, iOS 13, tvOS 13, watchOS 6, *)
-extension ResourceObject: Swift.Identifiable where EntityRawIdType: JSONAPI.RawIdType {}
+//@available(OSX 10.15, iOS 13, tvOS 13, watchOS 6, *)
+//extension ResourceObject: Swift.Identifiable where EntityRawIdType: JSONAPI.RawIdType {}
 
 extension ResourceObject: CustomStringConvertible {
     public var description: String {

--- a/Sources/JSONAPI/Resource/Resource Object/ResourceObjectDecodingError.swift
+++ b/Sources/JSONAPI/Resource/Resource Object/ResourceObjectDecodingError.swift
@@ -77,7 +77,7 @@ public struct ResourceObjectDecodingError: Swift.Error, Equatable {
     init?(_ jsonAPIError: JSONAPICodingError, jsonAPIType: String) {
         self.resourceObjectJsonAPIType = jsonAPIType
         switch jsonAPIError {
-        case .typeMismatch(expected: let expected, found: let found, path: let path):
+        case .typeMismatch(expected: _, found: let found, path: let path):
             (location, subjectName) = Self.context(path: path)
             cause = .jsonTypeMismatch(foundType: found)
         case .quantityMismatch(expected: let expected, path: let path):


### PR DESCRIPTION
Closes https://github.com/mattpolzin/JSONAPI/issues/92.

Swift was having trouble with a typealias created on a protocol the ResourceObject type conformed to. I was able to get things compiling by swapping out the typealias for the underlying type it referenced for the property definition on the generic ResourceObject type.