### PR TITLE
chore: allow mixing meta while merging Body.Data

### DIFF
--- a/Sources/JSONAPI/Document/Document.swift
+++ b/Sources/JSONAPI/Document/Document.swift
@@ -272,11 +272,11 @@ extension Document.Body.Data where PrimaryResourceBody: ResourceBodyAppendable {
 }
 
 extension Document.Body.Data where PrimaryResourceBody: ResourceBodyAppendable, MetaType == NoMetadata, LinksType == NoLinks {
-    public func merging<OtherMeta, OtherLinks, OtherDescription, OtherError>(_ other: Document<PrimaryResourceBody, OtherMeta, OtherLinks, IncludeType, OtherDescription, OtherError>.Body.Data) -> Document.Body.Data {
-        return Document.Body.Data(primary: primary.appending(other.primary),
-                                  includes: includes.appending(other.includes),
-                                  meta: meta,
-                                  links: links)
+    public func merging<OtherMeta, OtherLinks, OtherDescription, OtherError>(_ other: Document<PrimaryResourceBody, OtherMeta, OtherLinks, IncludeType, OtherDescription, OtherError>.Body.Data) -> Document<PrimaryResourceBody, OtherMeta, OtherLinks, IncludeType, APIDescription, Error>.Body.Data {
+        return .init(primary: primary.appending(other.primary),
+                     includes: includes.appending(other.includes),
+                     meta: other.meta,
+                     links: other.links)
     }
 }
 

--- a/Sources/JSONAPI/Document/Document.swift
+++ b/Sources/JSONAPI/Document/Document.swift
@@ -261,7 +261,7 @@ extension Document {
 }
 
 extension Document.Body.Data where PrimaryResourceBody: ResourceBodyAppendable {
-    public func merging(_ other: Document.Body.Data,
+    public func merging<OtherDescription, OtherError>(_ other: Document<PrimaryResourceBody, MetaType, LinksType, IncludeType, OtherDescription, OtherError>.Body.Data,
                         combiningMetaWith metaMerge: (MetaType, MetaType) -> MetaType,
                         combiningLinksWith linksMerge: (LinksType, LinksType) -> LinksType) -> Document.Body.Data {
         return Document.Body.Data(primary: primary.appending(other.primary),
@@ -272,10 +272,11 @@ extension Document.Body.Data where PrimaryResourceBody: ResourceBodyAppendable {
 }
 
 extension Document.Body.Data where PrimaryResourceBody: ResourceBodyAppendable, MetaType == NoMetadata, LinksType == NoLinks {
-    public func merging(_ other: Document.Body.Data) -> Document.Body.Data {
-        return merging(other,
-                       combiningMetaWith: { _, _ in .none },
-                       combiningLinksWith: { _, _ in .none })
+    public func merging<OtherMeta, OtherLinks, OtherDescription, OtherError>(_ other: Document<PrimaryResourceBody, OtherMeta, OtherLinks, IncludeType, OtherDescription, OtherError>.Body.Data) -> Document.Body.Data {
+        return Document.Body.Data(primary: primary.appending(other.primary),
+                                  includes: includes.appending(other.includes),
+                                  meta: meta,
+                                  links: links)
     }
 }
 

--- a/Tests/JSONAPITests/Document/DocumentTests.swift
+++ b/Tests/JSONAPITests/Document/DocumentTests.swift
@@ -1528,6 +1528,23 @@ extension DocumentTests {
 		XCTAssertEqual(combined.primary.values, bodyData1.primary.values + bodyData2.primary.values)
 	}
 
+  public func test_MergeBodyDataMixedMetaLinksErrorAndAPI(){
+    let entity1 = Article(attributes: .none, relationships: .init(author: "2"), meta: .none, links: .none)
+    let entity2 = Article(attributes: .none, relationships: .init(author: "3"), meta: .none, links: .none)
+
+    let bodyData1 = Document<ManyResourceBody<Article>, NoMetadata, NoLinks, NoIncludes, NoAPIDescription, UnknownJSONAPIError>.Body.Data(primary: .init(resourceObjects: [entity1]),
+                                                                                                                                          includes: .none,
+                                                                                                                                          meta: .none,
+                                                                                                                                          links: .none)
+    let bodyData2 = Document<ManyResourceBody<Article>, TestPageMetadata, TestLinks, NoIncludes, TestAPIDescription, GenericJSONAPIError<String>>.Body.Data(primary: .init(resourceObjects: [entity2]),
+                                                                                                                                          includes: .none,
+                                                                                                                                                meta: .init(total: 5, limit: 2, offset: 2),
+                                                                                                                                                  links: .init(link: .init(url: "one"), link2: .init(url: .init(), meta: .init(hello: "world"))))
+    let combined = bodyData1.merging(bodyData2)
+
+    XCTAssertEqual(combined.primary.values, bodyData1.primary.values + bodyData2.primary.values)
+  }
+
 	public func test_MergeBodyDataWithMergeFunctions() {
 		let article1 = Article(attributes: .none, relationships: .init(author: "2"), meta: .none, links: .none)
 		let author1 = Author(id: "2", attributes: .none, relationships: .none, meta: .none, links: .none)

--- a/Tests/JSONAPITests/Document/DocumentTests.swift
+++ b/Tests/JSONAPITests/Document/DocumentTests.swift
@@ -1543,6 +1543,8 @@ extension DocumentTests {
     let combined = bodyData1.merging(bodyData2)
 
     XCTAssertEqual(combined.primary.values, bodyData1.primary.values + bodyData2.primary.values)
+    XCTAssertEqual(combined.meta, bodyData2.meta)
+    XCTAssertEqual(combined.links, bodyData2.links)
   }
 
 	public func test_MergeBodyDataWithMergeFunctions() {


### PR DESCRIPTION
Ignore irrelevant generic types when merging `Document.Body.Data`.

I have a paginated request, and the response data has no meta and links because it’s irrelevant in the case when Meta is `NoMetadata`.

Also, made it possible to merge data with different API descriptions and errors.